### PR TITLE
Update modelsGen to translate an empty struct.

### DIFF
--- a/src/modelsGen.ts
+++ b/src/modelsGen.ts
@@ -95,6 +95,8 @@ async function main() {
           }
           if (subSchema.type === 'object' && (subSchema as any).properties) {
             return `${key}: ${makeTypeStringForNode(subSchema, key)}`;
+          } else if (subSchema.type === 'object') {
+            return `${key}: object`;
           }
           console.log(subSchema, key);
           throw 'subSchema not implemented ' + subSchema.type;


### PR DESCRIPTION
We've just added a new WebSocket message that's empty -- the specific case in question is the MetricsRequest, which has no properties (currently). This breaks the type translation, since no other types have no properties.

This will translate an empty type to an "object", since the only well-formed representation of an empty struct is an empty object, in our case.