### PR TITLE
Move `eslint-plugin-jest` from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/parser": "~8.4",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "~8.5",
+    "eslint-plugin-jest": "^28.8.3",
     "fast-json-patch": "^3.1.1",
     "prettier": "^2.8.1",
     "rimraf": "~3.0",
@@ -72,7 +73,6 @@
   "author": "Kurt Hutten <kurt@zoo.dev>",
   "license": "MIT",
   "dependencies": {
-    "eslint-plugin-jest": "^28.8.3",
     "openapi-types": "^12.0.0",
     "ts-node": "^10.9.1",
     "tslib": "~2.4"


### PR DESCRIPTION
The addition of a new dependency had cascading effects on this library's use in our modeling app, and ESLint plugins should always be dev dependencies.