### PR TITLE
Release v2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
My bad I should have just incorporated this into my last PR.

## Changelog
- Move an eslint plugin from a `dependency` to a `devDependency` so users aren't subjected to new ESLint version woes downstream