### PR TITLE
ci(gha): PATs are for Jerrys, use GitHub App token for docs sync

### DIFF
--- a/.github/workflows/update-spec-for-docs.yml
+++ b/.github/workflows/update-spec-for-docs.yml
@@ -18,7 +18,17 @@ jobs:
   update-spec:
     name: update-spec
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_ORG_APP_ID }}
+          private-key: ${{ secrets.GH_ORG_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -42,7 +52,7 @@ jobs:
         with:
           repository: 'kittycad/website'
           path: 'docs'
-          token: ${{secrets.KITTYCAD_TS_PAT}}
+          token: ${{ steps.app-token.outputs.token }}
       - name: move spec to docs
         shell: bash
         run: |
@@ -69,4 +79,4 @@ jobs:
               --reviewer franknoirot \
               --base main || true
         env:
-          GITHUB_TOKEN: ${{secrets.KITTYCAD_TS_PAT}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
- Replace KITTYCAD_TS_PAT with actions/create-github-app-token output for website checkout and PR creation; safer, auto-rotating
- Add permissions (contents write, pull-requests write) so the workflow can push and open PRs