### PR TITLE
fix(gen): stop stuffing 'undefined' in query strings, Morty

### DIFF
--- a/__tests__/forms/urlencoded.test.js
+++ b/__tests__/forms/urlencoded.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { oauth2 } from '../../src/index.ts'
+
+function makeRes(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('application/x-www-form-urlencoded bodies', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('encodes form data and omits undefined', async () => {
+    const mock = vi.fn((url, opts) => makeRes({ ok: true }))
+    globalThis.fetch = mock
+
+    await oauth2.device_access_token({
+      body: {
+        client_id: '00000000-0000-0000-0000-000000000000',
+        device_code: '11111111-1111-1111-1111-111111111111',
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      },
+    })
+
+    expect(mock).toHaveBeenCalledTimes(1)
+    const [, opts] = mock.mock.calls[0]
+    expect(opts.method).toBe('POST')
+    expect(String(opts.headers['Content-Type'])).toContain(
+      'application/x-www-form-urlencoded'
+    )
+    const bodyStr = opts.body && opts.body.toString ? opts.body.toString() : ''
+    expect(bodyStr).toContain('client_id=00000000-0000-0000-0000-000000000000')
+    expect(bodyStr).toContain(
+      'device_code=11111111-1111-1111-1111-111111111111'
+    )
+    expect(bodyStr).toContain(
+      'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code'
+    )
+    expect(bodyStr).not.toContain('undefined')
+  })
+})

--- a/__tests__/gen/oauth2-device_access_token.test.ts
+++ b/__tests__/gen/oauth2-device_access_token.test.ts
@@ -1,7 +1,13 @@
 import { oauth2, ApiError } from '../../src/index.js'
 
 async function example() {
-  const response = await oauth2.device_access_token()
+  const response = await oauth2.device_access_token({
+    body: {
+      client_id: 'The client ID.',
+      device_code: 'The device code.',
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    },
+  })
   return response
 }
 

--- a/__tests__/gen/oauth2-device_auth_request.test.ts
+++ b/__tests__/gen/oauth2-device_auth_request.test.ts
@@ -1,7 +1,9 @@
 import { oauth2, ApiError } from '../../src/index.js'
 
 async function example() {
-  const response = await oauth2.device_auth_request()
+  const response = await oauth2.device_auth_request({
+    body: { client_id: 'The client ID.' },
+  })
   return response
 }
 

--- a/__tests__/gen/oauth2-oauth2_token_revoke.test.ts
+++ b/__tests__/gen/oauth2-oauth2_token_revoke.test.ts
@@ -1,7 +1,13 @@
 import { oauth2, ApiError } from '../../src/index.js'
 
 async function example() {
-  const response = await oauth2.oauth2_token_revoke()
+  const response = await oauth2.oauth2_token_revoke({
+    body: {
+      client_id: 'The client ID.',
+      client_secret: 'The client secret.',
+      token: 'An auth token. A uuid with a prefix of dev-',
+    },
+  })
   return response
 }
 

--- a/__tests__/pagination/omit-undefined-query.test.js
+++ b/__tests__/pagination/omit-undefined-query.test.js
@@ -18,9 +18,9 @@ describe('query building skips undefined params', () => {
   })
 
   it('does not include page_token/conversation_id when undefined', async () => {
-    const mock = vi.fn().mockResolvedValueOnce(
-      makeRes({ items: [], next_page: null })
-    )
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(makeRes({ items: [], next_page: null }))
     globalThis.fetch = mock
 
     await ml.list_text_to_cad_models_for_user({
@@ -41,4 +41,3 @@ describe('query building skips undefined params', () => {
     expect(calledUrl).not.toContain('undefined')
   })
 })
-

--- a/__tests__/pagination/omit-undefined-query.test.js
+++ b/__tests__/pagination/omit-undefined-query.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ml } from '../../src/index.ts'
 
-function makeRes(body: unknown) {
+function makeRes(body) {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
@@ -18,9 +18,9 @@ describe('query building skips undefined params', () => {
   })
 
   it('does not include page_token/conversation_id when undefined', async () => {
-    const mock = vi
-      .fn()
-      .mockResolvedValueOnce(makeRes({ items: [], next_page: null }))
+    const mock = vi.fn().mockResolvedValueOnce(
+      makeRes({ items: [], next_page: null })
+    )
     globalThis.fetch = mock
 
     await ml.list_text_to_cad_models_for_user({
@@ -41,3 +41,4 @@ describe('query building skips undefined params', () => {
     expect(calledUrl).not.toContain('undefined')
   })
 })
+

--- a/__tests__/pagination/omit-undefined-query.test.ts
+++ b/__tests__/pagination/omit-undefined-query.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ml } from '../../src/index.ts'
+
+function makeRes(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('query building skips undefined params', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('does not include page_token/conversation_id when undefined', async () => {
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(makeRes({ items: [], next_page: null }))
+    globalThis.fetch = mock
+
+    await ml.list_text_to_cad_models_for_user({
+      limit: 5,
+      sort_by: 'created_at_descending',
+      no_models: true,
+      // page_token and conversation_id intentionally omitted (undefined)
+    })
+
+    expect(mock).toHaveBeenCalledTimes(1)
+    const calledUrl = String(mock.mock.calls[0][0])
+    expect(calledUrl).toContain('/user/text-to-cad')
+    expect(calledUrl).toContain('limit=5')
+    expect(calledUrl).toContain('sort_by=created_at_descending')
+    expect(calledUrl).toContain('no_models=true')
+    expect(calledUrl).not.toContain('page_token=')
+    expect(calledUrl).not.toContain('conversation_id=')
+    expect(calledUrl).not.toContain('undefined')
+  })
+})

--- a/gen/templates/multipart.hbs
+++ b/gen/templates/multipart.hbs
@@ -1,5 +1,5 @@
 import { File } from '../../models.js';
-import { Client } from '../../client.js';
+import { Client, buildQuery } from '../../client.js';
 import { throwIfNotOk } from '../../errors.js';
 
 {{{importsModels}}}
@@ -12,7 +12,9 @@ import { throwIfNotOk } from '../../errors.js';
 export default async function {{functionName}}(
   {{{paramsSignature}}}
 ): Promise<{{returnTypeName}}> {
-  const url = {{{urlExpr}}};
+  const path = {{{urlPathExpr}}};
+  const qs = buildQuery({{{queryObjectExpr}}});
+  const url = path + qs;
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.
@@ -56,4 +58,3 @@ export default async function {{functionName}}(
   return result;
   {{/if}}
 }
-

--- a/gen/templates/rest.hbs
+++ b/gen/templates/rest.hbs
@@ -1,4 +1,4 @@
-import { Client, buildQuery } from '../../client.js';
+import { Client, buildQuery{{#if isUrlEncoded}}, buildForm{{/if}} } from '../../client.js';
 import { throwIfNotOk } from '../../errors.js';
 {{#if pager}}
 import { Pager, createPager } from '../../pagination.js';

--- a/gen/templates/rest.hbs
+++ b/gen/templates/rest.hbs
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js';
+import { Client, buildQuery } from '../../client.js';
 import { throwIfNotOk } from '../../errors.js';
 {{#if pager}}
 import { Pager, createPager } from '../../pagination.js';
@@ -14,7 +14,9 @@ import { Pager, createPager } from '../../pagination.js';
 export default async function {{functionName}}(
   {{{paramsSignature}}}
 ): Promise<{{returnTypeName}}> {
-  const url = {{{urlExpr}}};
+  const path = {{{urlPathExpr}}};
+  const qs = buildQuery({{{queryObjectExpr}}});
+  const url = path + qs;
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.
@@ -64,4 +66,3 @@ export function {{pagerFnName}}(
   );
 }
 {{/if}}
-

--- a/gen/templates/ws.hbs
+++ b/gen/templates/ws.hbs
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js';
+import { Client, buildQuery } from '../../client.js';
 import { BSON } from 'bson';
 import type { Document } from 'bson';
 import { isArrayBufferViewLike } from '../../ws-utils.js';
@@ -17,9 +17,11 @@ export default class {{className}}<Req = {{{wsReqType}}}, Res = {{{wsRespType}}}
   /**
    * Establish the WebSocket connection and perform optional header auth.
    * @returns {Promise<this>} WebSocket instance after the connection opens.
-   */
+  */
   async connect(): Promise<this> {
-    const url = {{{urlExpr}}};
+    const path = {{{urlPathExpr}}};
+    const qs = buildQuery({{{queryObjectExpr}}});
+    const url = path + qs;
     // Backwards compatible for the BASE_URL env variable
     // That used to exist in only this lib, ZOO_HOST exists in the all the other
     // sdks and the CLI.
@@ -121,4 +123,3 @@ export default class {{className}}<Req = {{{wsReqType}}}, Res = {{{wsRespType}}}
     return data as Res;
   }
 }
-

--- a/kittycad.ts.patch.json
+++ b/kittycad.ts.patch.json
@@ -859,7 +859,7 @@
     "op": "add",
     "path": "/paths/~1oauth2~1token~1revoke/post/x-typescript",
     "value": {
-      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.oauth2_token_revoke()\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
+      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.oauth2_token_revoke({\n        body: {\n            client_id: 'The client ID.',\n            client_secret: 'The client secret.',\n            token: 'An auth token. A uuid with a prefix of dev-',\n        },\n    })\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
       "libDocsLink": ""
     }
   },
@@ -875,7 +875,7 @@
     "op": "add",
     "path": "/paths/~1oauth2~1provider~1{provider}~1callback/post/x-typescript",
     "value": {
-      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.oauth2_provider_callback_post({\n        provider: 'apple',\n    })\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
+      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.oauth2_provider_callback_post({\n        provider: 'apple',\n        body: {\n            code: 'The authorization code.',\n            id_token:\n                'For Apple only, a JSON web token containing the user’s identity information.',\n            state: 'The state that we had passed in through the user consent URL.',\n            user: \"For Apple only, a JSON string containing the data requested in the scope property. The returned data is in the following format: `{ 'name': { 'firstName': string, 'lastName': string }, 'email': string }`\",\n        },\n    })\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
       "libDocsLink": ""
     }
   },
@@ -899,7 +899,7 @@
     "op": "add",
     "path": "/paths/~1oauth2~1device~1token/post/x-typescript",
     "value": {
-      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.device_access_token()\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
+      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.device_access_token({\n        body: {\n            client_id: 'The client ID.',\n            device_code: 'The device code.',\n            grant_type: 'urn:ietf:params:oauth:grant-type:device_code',\n        },\n    })\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
       "libDocsLink": ""
     }
   },
@@ -915,7 +915,7 @@
     "op": "add",
     "path": "/paths/~1oauth2~1device~1auth/post/x-typescript",
     "value": {
-      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.device_auth_request()\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
+      "example": "import { oauth2, ApiError } from '@kittycad/lib'\n\nasync function example() {\n    const response = await oauth2.device_auth_request({\n        body: { client_id: 'The client ID.' },\n    })\n}\n\n// Error handling\ntry {\n    const res = await example()\n} catch (e) {\n    if (e instanceof ApiError) {\n        console.error('status', e.status, 'code', e.body?.error_code)\n        console.error('message', e.body?.message)\n        console.error('request_id', e.body?.request_id)\n    } else {\n        throw e\n    }\n}\n",
       "libDocsLink": ""
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "3.0.2",
+  "version": "3.0.1",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/api/api-calls/get_api_call.ts
+++ b/src/api/api-calls/get_api_call.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiCallWithPrice } from '../../models.js'
@@ -32,7 +32,9 @@ export default async function get_api_call({
   client,
   id,
 }: GetApiCallInput): Promise<GetApiCallReturn> {
-  const url = `/api-calls/${id}`
+  const path = `/api-calls/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/get_api_call_for_org.ts
+++ b/src/api/api-calls/get_api_call_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiCallWithPrice } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_api_call_for_org({
   client,
   id,
 }: GetApiCallForOrgInput): Promise<GetApiCallForOrgReturn> {
-  const url = `/org/api-calls/${id}`
+  const path = `/org/api-calls/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/get_api_call_for_user.ts
+++ b/src/api/api-calls/get_api_call_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiCallWithPrice } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_api_call_for_user({
   client,
   id,
 }: GetApiCallForUserInput): Promise<GetApiCallForUserReturn> {
-  const url = `/user/api-calls/${id}`
+  const path = `/user/api-calls/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/get_api_call_metrics.ts
+++ b/src/api/api-calls/get_api_call_metrics.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiCallQueryGroup, ApiCallQueryGroupBy } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_api_call_metrics({
   client,
   group_by,
 }: GetApiCallMetricsInput): Promise<GetApiCallMetricsReturn> {
-  const url = `/api-call-metrics?group_by=${group_by}`
+  const path = `/api-call-metrics`
+  const qs = buildQuery({ group_by: group_by })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/get_async_operation.ts
+++ b/src/api/api-calls/get_async_operation.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { AsyncApiCallOutput } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_async_operation({
   client,
   id,
 }: GetAsyncOperationInput): Promise<GetAsyncOperationReturn> {
-  const url = `/async/operations/${id}`
+  const path = `/async/operations/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/list_api_calls.ts
+++ b/src/api/api-calls/list_api_calls.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListApiCallsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListApiCallsReturn = ApiCallWithPriceResultsPage
@@ -39,7 +39,13 @@ export default async function list_api_calls({
   page_token,
   sort_by,
 }: ListApiCallsInput): Promise<ListApiCallsReturn> {
-  const url = `/api-calls?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/api-calls`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/list_api_calls_for_user.ts
+++ b/src/api/api-calls/list_api_calls_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -12,9 +12,9 @@ import {
 interface ListApiCallsForUserInput {
   client?: Client
   id: UserIdentifier
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListApiCallsForUserReturn = ApiCallWithPriceResultsPage
@@ -49,7 +49,13 @@ export default async function list_api_calls_for_user({
   page_token,
   sort_by,
 }: ListApiCallsForUserInput): Promise<ListApiCallsForUserReturn> {
-  const url = `/users/${id}/api-calls?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/users/${id}/api-calls`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/list_async_operations.ts
+++ b/src/api/api-calls/list_async_operations.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -11,10 +11,10 @@ import {
 
 interface ListAsyncOperationsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
-  status: ApiCallStatus
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
+  status?: ApiCallStatus
 }
 
 type ListAsyncOperationsReturn = AsyncApiCallResultsPage
@@ -45,7 +45,14 @@ export default async function list_async_operations({
   sort_by,
   status,
 }: ListAsyncOperationsInput): Promise<ListAsyncOperationsReturn> {
-  const url = `/async/operations?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}&status=${status}`
+  const path = `/async/operations`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+    status: status,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/org_list_api_calls.ts
+++ b/src/api/api-calls/org_list_api_calls.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface OrgListApiCallsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type OrgListApiCallsReturn = ApiCallWithPriceResultsPage
@@ -43,7 +43,13 @@ export default async function org_list_api_calls({
   page_token,
   sort_by,
 }: OrgListApiCallsInput): Promise<OrgListApiCallsReturn> {
-  const url = `/org/api-calls?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/org/api-calls`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-calls/user_list_api_calls.ts
+++ b/src/api/api-calls/user_list_api_calls.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface UserListApiCallsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type UserListApiCallsReturn = ApiCallWithPriceResultsPage
@@ -41,7 +41,13 @@ export default async function user_list_api_calls({
   page_token,
   sort_by,
 }: UserListApiCallsInput): Promise<UserListApiCallsReturn> {
-  const url = `/user/api-calls?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/user/api-calls`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-tokens/create_api_token_for_user.ts
+++ b/src/api/api-tokens/create_api_token_for_user.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiToken } from '../../models.js'
 
 interface CreateApiTokenForUserInput {
   client?: Client
-  label: string
+  label?: string
 }
 
 type CreateApiTokenForUserReturn = ApiToken
@@ -28,7 +28,9 @@ export default async function create_api_token_for_user({
   client,
   label,
 }: CreateApiTokenForUserInput): Promise<CreateApiTokenForUserReturn> {
-  const url = `/user/api-tokens?label=${label}`
+  const path = `/user/api-tokens`
+  const qs = buildQuery({ label: label })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-tokens/delete_api_token_for_user.ts
+++ b/src/api/api-tokens/delete_api_token_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiTokenUuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function delete_api_token_for_user({
   client,
   token,
 }: DeleteApiTokenForUserInput): Promise<DeleteApiTokenForUserReturn> {
-  const url = `/user/api-tokens/${token}`
+  const path = `/user/api-tokens/${token}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-tokens/get_api_token_for_user.ts
+++ b/src/api/api-tokens/get_api_token_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiToken, ApiTokenUuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_api_token_for_user({
   client,
   token,
 }: GetApiTokenForUserInput): Promise<GetApiTokenForUserReturn> {
-  const url = `/user/api-tokens/${token}`
+  const path = `/user/api-tokens/${token}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/api-tokens/list_api_tokens_for_user.ts
+++ b/src/api/api-tokens/list_api_tokens_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListApiTokensForUserInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListApiTokensForUserReturn = ApiTokenResultsPage
@@ -41,7 +41,13 @@ export default async function list_api_tokens_for_user({
   page_token,
   sort_by,
 }: ListApiTokensForUserInput): Promise<ListApiTokensForUserReturn> {
-  const url = `/user/api-tokens?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/user/api-tokens`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/apps/apps_github_callback.ts
+++ b/src/api/apps/apps_github_callback.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -25,7 +25,9 @@ type AppsGithubCallbackReturn = void
 export default async function apps_github_callback(
   { client }: AppsGithubCallbackInput = {} as AppsGithubCallbackInput
 ): Promise<AppsGithubCallbackReturn> {
-  const url = `/apps/github/callback`
+  const path = `/apps/github/callback`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/apps/apps_github_consent.ts
+++ b/src/api/apps/apps_github_consent.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { AppClientInfo } from '../../models.js'
@@ -27,7 +27,9 @@ type AppsGithubConsentReturn = AppClientInfo
 export default async function apps_github_consent(
   { client }: AppsGithubConsentInput = {} as AppsGithubConsentInput
 ): Promise<AppsGithubConsentReturn> {
-  const url = `/apps/github/consent`
+  const path = `/apps/github/consent`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/apps/apps_github_webhook.ts
+++ b/src/api/apps/apps_github_webhook.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -26,7 +26,9 @@ export default async function apps_github_webhook({
   client,
   body,
 }: AppsGithubWebhookInput): Promise<AppsGithubWebhookReturn> {
-  const url = `/apps/github/webhook`
+  const path = `/apps/github/webhook`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/executor/create_executor_term.ts
+++ b/src/api/executor/create_executor_term.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { BSON } from 'bson'
 import type { Document } from 'bson'
 import { isArrayBufferViewLike } from '../../ws-utils.js'
@@ -30,7 +30,9 @@ export default class ExecutorTerm<Req = unknown, Res = unknown> {
    * @returns {Promise<this>} WebSocket instance after the connection opens.
    */
   async connect(): Promise<this> {
-    const url = `/ws/executor/term`
+    const path = `/ws/executor/term`
+    const qs = buildQuery({})
+    const url = path + qs
     // Backwards compatible for the BASE_URL env variable
     // That used to exist in only this lib, ZOO_HOST exists in the all the other
     // sdks and the CLI.

--- a/src/api/executor/create_file_execution.ts
+++ b/src/api/executor/create_file_execution.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CodeOutput, CodeLanguage } from '../../models.js'
@@ -6,7 +6,7 @@ import { CodeOutput, CodeLanguage } from '../../models.js'
 interface CreateFileExecutionInput {
   client?: Client
   lang: CodeLanguage
-  output: string
+  output?: string
   body: string
 }
 
@@ -32,7 +32,9 @@ export default async function create_file_execution({
   output,
   body,
 }: CreateFileExecutionInput): Promise<CreateFileExecutionReturn> {
-  const url = `/file/execute/${lang}?output=${output}`
+  const path = `/file/execute/${lang}`
+  const qs = buildQuery({ output: output })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_center_of_mass.ts
+++ b/src/api/file/create_file_center_of_mass.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { FileCenterOfMass, UnitLength, FileImportFormat } from '../../models.js'
 
 interface CreateFileCenterOfMassInput {
   client?: Client
-  output_unit: UnitLength
+  output_unit?: UnitLength
   src_format: FileImportFormat
   body: string
 }
@@ -42,7 +42,9 @@ export default async function create_file_center_of_mass({
   src_format,
   body,
 }: CreateFileCenterOfMassInput): Promise<CreateFileCenterOfMassReturn> {
-  const url = `/file/center-of-mass?output_unit=${output_unit}&src_format=${src_format}`
+  const path = `/file/center-of-mass`
+  const qs = buildQuery({ output_unit: output_unit, src_format: src_format })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_conversion.ts
+++ b/src/api/file/create_file_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -44,7 +44,9 @@ export default async function create_file_conversion({
   src_format,
   body,
 }: CreateFileConversionInput): Promise<CreateFileConversionReturn> {
-  const url = `/file/conversion/${src_format}/${output_format}`
+  const path = `/file/conversion/${src_format}/${output_format}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_conversion_options.ts
+++ b/src/api/file/create_file_conversion_options.ts
@@ -1,5 +1,5 @@
 import { File } from '../../models.js'
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { FileConversion, ConversionParams } from '../../models.js'
@@ -36,7 +36,9 @@ export default async function create_file_conversion_options({
   files,
   body,
 }: CreateFileConversionOptionsInput): Promise<CreateFileConversionOptionsReturn> {
-  const url = `/file/conversion`
+  const path = `/file/conversion`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_density.ts
+++ b/src/api/file/create_file_density.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -11,8 +11,8 @@ import {
 interface CreateFileDensityInput {
   client?: Client
   material_mass: number
-  material_mass_unit: UnitMass
-  output_unit: UnitDensity
+  material_mass_unit?: UnitMass
+  output_unit?: UnitDensity
   src_format: FileImportFormat
   body: string
 }
@@ -53,7 +53,14 @@ export default async function create_file_density({
   src_format,
   body,
 }: CreateFileDensityInput): Promise<CreateFileDensityReturn> {
-  const url = `/file/density?material_mass=${material_mass}&material_mass_unit=${material_mass_unit}&output_unit=${output_unit}&src_format=${src_format}`
+  const path = `/file/density`
+  const qs = buildQuery({
+    material_mass: material_mass,
+    material_mass_unit: material_mass_unit,
+    output_unit: output_unit,
+    src_format: src_format,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_mass.ts
+++ b/src/api/file/create_file_mass.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -11,8 +11,8 @@ import {
 interface CreateFileMassInput {
   client?: Client
   material_density: number
-  material_density_unit: UnitDensity
-  output_unit: UnitMass
+  material_density_unit?: UnitDensity
+  output_unit?: UnitMass
   src_format: FileImportFormat
   body: string
 }
@@ -53,7 +53,14 @@ export default async function create_file_mass({
   src_format,
   body,
 }: CreateFileMassInput): Promise<CreateFileMassReturn> {
-  const url = `/file/mass?material_density=${material_density}&material_density_unit=${material_density_unit}&output_unit=${output_unit}&src_format=${src_format}`
+  const path = `/file/mass`
+  const qs = buildQuery({
+    material_density: material_density,
+    material_density_unit: material_density_unit,
+    output_unit: output_unit,
+    src_format: src_format,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_surface_area.ts
+++ b/src/api/file/create_file_surface_area.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { FileSurfaceArea, UnitArea, FileImportFormat } from '../../models.js'
 
 interface CreateFileSurfaceAreaInput {
   client?: Client
-  output_unit: UnitArea
+  output_unit?: UnitArea
   src_format: FileImportFormat
   body: string
 }
@@ -42,7 +42,9 @@ export default async function create_file_surface_area({
   src_format,
   body,
 }: CreateFileSurfaceAreaInput): Promise<CreateFileSurfaceAreaReturn> {
-  const url = `/file/surface-area?output_unit=${output_unit}&src_format=${src_format}`
+  const path = `/file/surface-area`
+  const qs = buildQuery({ output_unit: output_unit, src_format: src_format })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/file/create_file_volume.ts
+++ b/src/api/file/create_file_volume.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { FileVolume, UnitVolume, FileImportFormat } from '../../models.js'
 
 interface CreateFileVolumeInput {
   client?: Client
-  output_unit: UnitVolume
+  output_unit?: UnitVolume
   src_format: FileImportFormat
   body: string
 }
@@ -42,7 +42,9 @@ export default async function create_file_volume({
   src_format,
   body,
 }: CreateFileVolumeInput): Promise<CreateFileVolumeReturn> {
-  const url = `/file/volume?output_unit=${output_unit}&src_format=${src_format}`
+  const path = `/file/volume`
+  const qs = buildQuery({ output_unit: output_unit, src_format: src_format })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/community_sso.ts
+++ b/src/api/meta/community_sso.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -27,7 +27,9 @@ export default async function community_sso({
   sig,
   sso,
 }: CommunitySsoInput): Promise<CommunitySsoReturn> {
-  const url = `/community/sso?sig=${sig}&sso=${sso}`
+  const path = `/community/sso`
+  const qs = buildQuery({ sig: sig, sso: sso })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/create_debug_uploads.ts
+++ b/src/api/meta/create_debug_uploads.ts
@@ -1,5 +1,5 @@
 import { File } from '../../models.js'
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -27,7 +27,9 @@ export default async function create_debug_uploads({
   client,
   files,
 }: CreateDebugUploadsInput): Promise<CreateDebugUploadsReturn> {
-  const url = `/debug/uploads`
+  const path = `/debug/uploads`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/create_event.ts
+++ b/src/api/meta/create_event.ts
@@ -1,5 +1,5 @@
 import { File } from '../../models.js'
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Event } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function create_event({
   files,
   body,
 }: CreateEventInput): Promise<CreateEventReturn> {
-  const url = `/events`
+  const path = `/events`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/get_ipinfo.ts
+++ b/src/api/meta/get_ipinfo.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { IpAddrInfo } from '../../models.js'
@@ -23,7 +23,9 @@ type GetIpinfoReturn = IpAddrInfo
 export default async function get_ipinfo(
   { client }: GetIpinfoInput = {} as GetIpinfoInput
 ): Promise<GetIpinfoReturn> {
-  const url = `/_meta/ipinfo`
+  const path = `/_meta/ipinfo`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/get_pricing_subscriptions.ts
+++ b/src/api/meta/get_pricing_subscriptions.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ZooProductSubscription } from '../../models.js'
@@ -25,7 +25,9 @@ type GetPricingSubscriptionsReturn = ZooProductSubscription[]
 export default async function get_pricing_subscriptions(
   { client }: GetPricingSubscriptionsInput = {} as GetPricingSubscriptionsInput
 ): Promise<GetPricingSubscriptionsReturn> {
-  const url = `/pricing/subscriptions`
+  const path = `/pricing/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/get_schema.ts
+++ b/src/api/meta/get_schema.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -21,7 +21,9 @@ type GetSchemaReturn = unknown
 export default async function get_schema(
   { client }: GetSchemaInput = {} as GetSchemaInput
 ): Promise<GetSchemaReturn> {
-  const url = `/`
+  const path = `/`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/internal_get_api_token_for_discord_user.ts
+++ b/src/api/meta/internal_get_api_token_for_discord_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ApiToken } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function internal_get_api_token_for_discord_user({
   client,
   discord_id,
 }: InternalGetApiTokenForDiscordUserInput): Promise<InternalGetApiTokenForDiscordUserReturn> {
-  const url = `/internal/discord/api-token/${discord_id}`
+  const path = `/internal/discord/api-token/${discord_id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/meta/ping.ts
+++ b/src/api/meta/ping.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Pong } from '../../models.js'
@@ -23,7 +23,9 @@ type PingReturn = Pong
 export default async function ping(
   { client }: PingInput = {} as PingInput
 ): Promise<PingReturn> {
-  const url = `/ping`
+  const path = `/ping`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_kcl_code_completions.ts
+++ b/src/api/ml/create_kcl_code_completions.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -29,7 +29,9 @@ export default async function create_kcl_code_completions({
   client,
   body,
 }: CreateKclCodeCompletionsInput): Promise<CreateKclCodeCompletionsReturn> {
-  const url = `/ml/kcl/completions`
+  const path = `/ml/kcl/completions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_proprietary_to_kcl.ts
+++ b/src/api/ml/create_proprietary_to_kcl.ts
@@ -1,5 +1,5 @@
 import { File } from '../../models.js'
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { KclModel, CodeOption } from '../../models.js'
@@ -7,7 +7,7 @@ import { KclModel, CodeOption } from '../../models.js'
 interface CreateProprietaryToKclInput {
   client?: Client
   files: File[]
-  code_option: CodeOption
+  code_option?: CodeOption
 }
 
 type CreateProprietaryToKclReturn = KclModel
@@ -36,7 +36,9 @@ export default async function create_proprietary_to_kcl({
   files,
   code_option,
 }: CreateProprietaryToKclInput): Promise<CreateProprietaryToKclReturn> {
-  const url = `/ml/convert/proprietary-to-kcl?code_option=${code_option}`
+  const path = `/ml/convert/proprietary-to-kcl`
+  const qs = buildQuery({ code_option: code_option })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_text_to_cad.ts
+++ b/src/api/ml/create_text_to_cad.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -10,7 +10,7 @@ import {
 interface CreateTextToCadInput {
   client?: Client
   output_format: FileExportFormat
-  kcl: boolean
+  kcl?: boolean
   body: TextToCadCreateBody
 }
 
@@ -42,7 +42,9 @@ export default async function create_text_to_cad({
   kcl,
   body,
 }: CreateTextToCadInput): Promise<CreateTextToCadReturn> {
-  const url = `/ai/text-to-cad/${output_format}?kcl=${kcl}`
+  const path = `/ai/text-to-cad/${output_format}`
+  const qs = buildQuery({ kcl: kcl })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_text_to_cad_iteration.ts
+++ b/src/api/ml/create_text_to_cad_iteration.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { TextToCadIteration, TextToCadIterationBody } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function create_text_to_cad_iteration({
   client,
   body,
 }: CreateTextToCadIterationInput): Promise<CreateTextToCadIterationReturn> {
-  const url = `/ml/text-to-cad/iteration`
+  const path = `/ml/text-to-cad/iteration`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_text_to_cad_model_feedback.ts
+++ b/src/api/ml/create_text_to_cad_model_feedback.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { MlFeedback } from '../../models.js'
@@ -31,7 +31,9 @@ export default async function create_text_to_cad_model_feedback({
   id,
   feedback,
 }: CreateTextToCadModelFeedbackInput): Promise<CreateTextToCadModelFeedbackReturn> {
-  const url = `/user/text-to-cad/${id}?feedback=${feedback}`
+  const path = `/user/text-to-cad/${id}`
+  const qs = buildQuery({ feedback: feedback })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/create_text_to_cad_multi_file_iteration.ts
+++ b/src/api/ml/create_text_to_cad_multi_file_iteration.ts
@@ -1,5 +1,5 @@
 import { File } from '../../models.js'
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -43,7 +43,9 @@ export default async function create_text_to_cad_multi_file_iteration({
   files,
   body,
 }: CreateTextToCadMultiFileIterationInput): Promise<CreateTextToCadMultiFileIterationReturn> {
-  const url = `/ml/text-to-cad/multi-file/iteration`
+  const path = `/ml/text-to-cad/multi-file/iteration`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/get_ml_prompt.ts
+++ b/src/api/ml/get_ml_prompt.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { MlPrompt } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_ml_prompt({
   client,
   id,
 }: GetMlPromptInput): Promise<GetMlPromptReturn> {
-  const url = `/ml-prompts/${id}`
+  const path = `/ml-prompts/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/get_text_to_cad_model_for_user.ts
+++ b/src/api/ml/get_text_to_cad_model_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { TextToCadResponse } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_text_to_cad_model_for_user({
   client,
   id,
 }: GetTextToCadModelForUserInput): Promise<GetTextToCadModelForUserReturn> {
-  const url = `/user/text-to-cad/${id}`
+  const path = `/user/text-to-cad/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/list_conversations_for_user.ts
+++ b/src/api/ml/list_conversations_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListConversationsForUserInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListConversationsForUserReturn = ConversationResultsPage
@@ -41,7 +41,13 @@ export default async function list_conversations_for_user({
   page_token,
   sort_by,
 }: ListConversationsForUserInput): Promise<ListConversationsForUserReturn> {
-  const url = `/ml/conversations?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/ml/conversations`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/list_ml_prompts.ts
+++ b/src/api/ml/list_ml_prompts.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListMlPromptsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListMlPromptsReturn = MlPromptResultsPage
@@ -43,7 +43,13 @@ export default async function list_ml_prompts({
   page_token,
   sort_by,
 }: ListMlPromptsInput): Promise<ListMlPromptsReturn> {
-  const url = `/ml-prompts?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/ml-prompts`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/list_text_to_cad_models_for_user.ts
+++ b/src/api/ml/list_text_to_cad_models_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -11,11 +11,11 @@ import {
 
 interface ListTextToCadModelsForUserInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
-  conversation_id: Uuid
-  no_models: boolean
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
+  conversation_id?: Uuid
+  no_models?: boolean
 }
 
 type ListTextToCadModelsForUserReturn = TextToCadResponseResultsPage
@@ -50,7 +50,15 @@ export default async function list_text_to_cad_models_for_user({
   conversation_id,
   no_models,
 }: ListTextToCadModelsForUserInput): Promise<ListTextToCadModelsForUserReturn> {
-  const url = `/user/text-to-cad?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}&conversation_id=${conversation_id}&no_models=${no_models}`
+  const path = `/user/text-to-cad`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+    conversation_id: conversation_id,
+    no_models: no_models,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/ml/ml_copilot_ws.ts
+++ b/src/api/ml/ml_copilot_ws.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { BSON } from 'bson'
 import type { Document } from 'bson'
 import { isArrayBufferViewLike } from '../../ws-utils.js'
@@ -31,7 +31,9 @@ export default class MlCopilotWs<
    * @returns {Promise<this>} WebSocket instance after the connection opens.
    */
   async connect(): Promise<this> {
-    const url = `/ws/ml/copilot`
+    const path = `/ws/ml/copilot`
+    const qs = buildQuery({})
+    const url = path + qs
     // Backwards compatible for the BASE_URL env variable
     // That used to exist in only this lib, ZOO_HOST exists in the all the other
     // sdks and the CLI.

--- a/src/api/ml/ml_reasoning_ws.ts
+++ b/src/api/ml/ml_reasoning_ws.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { BSON } from 'bson'
 import type { Document } from 'bson'
 import { isArrayBufferViewLike } from '../../ws-utils.js'
@@ -33,7 +33,9 @@ export default class MlReasoningWs<
    * @returns {Promise<this>} WebSocket instance after the connection opens.
    */
   async connect(): Promise<this> {
-    const url = `/ws/ml/reasoning/${this.functionNameParams.id}`
+    const path = `/ws/ml/reasoning/${this.functionNameParams.id}`
+    const qs = buildQuery({})
+    const url = path + qs
     // Backwards compatible for the BASE_URL env variable
     // That used to exist in only this lib, ZOO_HOST exists in the all the other
     // sdks and the CLI.

--- a/src/api/modeling/modeling_commands_ws.ts
+++ b/src/api/modeling/modeling_commands_ws.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { BSON } from 'bson'
 import type { Document } from 'bson'
 import { isArrayBufferViewLike } from '../../ws-utils.js'
@@ -10,16 +10,16 @@ import {
 
 interface ModelingCommandsWsParams {
   client?: Client
-  api_call_id: string
-  fps: number
-  pool: string
-  post_effect: PostEffectType
-  replay: string
-  show_grid: boolean
-  unlocked_framerate: boolean
-  video_res_height: number
-  video_res_width: number
-  webrtc: boolean
+  api_call_id?: string
+  fps?: number
+  pool?: string
+  post_effect?: PostEffectType
+  replay?: string
+  show_grid?: boolean
+  unlocked_framerate?: boolean
+  video_res_height?: number
+  video_res_width?: number
+  webrtc?: boolean
 }
 
 /**
@@ -57,7 +57,20 @@ export default class ModelingCommandsWs<
    * @returns {Promise<this>} WebSocket instance after the connection opens.
    */
   async connect(): Promise<this> {
-    const url = `/ws/modeling/commands?api_call_id=${this.functionNameParams.api_call_id}&fps=${this.functionNameParams.fps}&pool=${this.functionNameParams.pool}&post_effect=${this.functionNameParams.post_effect}&replay=${this.functionNameParams.replay}&show_grid=${this.functionNameParams.show_grid}&unlocked_framerate=${this.functionNameParams.unlocked_framerate}&video_res_height=${this.functionNameParams.video_res_height}&video_res_width=${this.functionNameParams.video_res_width}&webrtc=${this.functionNameParams.webrtc}`
+    const path = `/ws/modeling/commands`
+    const qs = buildQuery({
+      api_call_id: this.functionNameParams.api_call_id,
+      fps: this.functionNameParams.fps,
+      pool: this.functionNameParams.pool,
+      post_effect: this.functionNameParams.post_effect,
+      replay: this.functionNameParams.replay,
+      show_grid: this.functionNameParams.show_grid,
+      unlocked_framerate: this.functionNameParams.unlocked_framerate,
+      video_res_height: this.functionNameParams.video_res_height,
+      video_res_width: this.functionNameParams.video_res_width,
+      webrtc: this.functionNameParams.webrtc,
+    })
+    const url = path + qs
     // Backwards compatible for the BASE_URL env variable
     // That used to exist in only this lib, ZOO_HOST exists in the all the other
     // sdks and the CLI.

--- a/src/api/oauth2/device_access_token.ts
+++ b/src/api/oauth2/device_access_token.ts
@@ -1,10 +1,11 @@
-import { Client, buildQuery } from '../../client.js'
+import { Client, buildQuery, buildForm } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
-import {} from '../../models.js'
+import { DeviceAccessTokenRequestForm } from '../../models.js'
 
 interface DeviceAccessTokenInput {
   client?: Client
+  body: DeviceAccessTokenRequestForm
 }
 
 type DeviceAccessTokenReturn = unknown
@@ -18,11 +19,13 @@ type DeviceAccessTokenReturn = unknown
  *
  * @param params Function parameters.
  * @property {Client} [client] Optional client with auth token.
+ * @property {DeviceAccessTokenRequestForm} body Request body payload
  * @returns {Promise<DeviceAccessTokenReturn>} Response payload.
  */
-export default async function device_access_token(
-  { client }: DeviceAccessTokenInput = {} as DeviceAccessTokenInput
-): Promise<DeviceAccessTokenReturn> {
+export default async function device_access_token({
+  client,
+  body,
+}: DeviceAccessTokenInput): Promise<DeviceAccessTokenReturn> {
   const path = `/oauth2/device/token`
   const qs = buildQuery({})
   const url = path + qs
@@ -47,9 +50,11 @@ export default async function device_access_token(
       ''
   const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
+  headers['Content-Type'] = 'application/x-www-form-urlencoded'
   const fetchOptions: RequestInit = {
     method: 'POST',
     headers,
+    body: buildForm(body as unknown as Record<string, unknown>),
   }
   const _fetch = client?.fetch || fetch
   const response = await _fetch(fullUrl, fetchOptions)

--- a/src/api/oauth2/device_access_token.ts
+++ b/src/api/oauth2/device_access_token.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -23,7 +23,9 @@ type DeviceAccessTokenReturn = unknown
 export default async function device_access_token(
   { client }: DeviceAccessTokenInput = {} as DeviceAccessTokenInput
 ): Promise<DeviceAccessTokenReturn> {
-  const url = `/oauth2/device/token`
+  const path = `/oauth2/device/token`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/device_auth_confirm.ts
+++ b/src/api/oauth2/device_auth_confirm.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { DeviceAuthConfirmParams } from '../../models.js'
@@ -26,7 +26,9 @@ export default async function device_auth_confirm({
   client,
   body,
 }: DeviceAuthConfirmInput): Promise<DeviceAuthConfirmReturn> {
-  const url = `/oauth2/device/confirm`
+  const path = `/oauth2/device/confirm`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/device_auth_request.ts
+++ b/src/api/oauth2/device_auth_request.ts
@@ -1,10 +1,11 @@
-import { Client, buildQuery } from '../../client.js'
+import { Client, buildQuery, buildForm } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
-import {} from '../../models.js'
+import { DeviceAuthRequestForm } from '../../models.js'
 
 interface DeviceAuthRequestInput {
   client?: Client
+  body: DeviceAuthRequestForm
 }
 
 type DeviceAuthRequestReturn = unknown
@@ -18,11 +19,13 @@ type DeviceAuthRequestReturn = unknown
  *
  * @param params Function parameters.
  * @property {Client} [client] Optional client with auth token.
+ * @property {DeviceAuthRequestForm} body Request body payload
  * @returns {Promise<DeviceAuthRequestReturn>} Response payload.
  */
-export default async function device_auth_request(
-  { client }: DeviceAuthRequestInput = {} as DeviceAuthRequestInput
-): Promise<DeviceAuthRequestReturn> {
+export default async function device_auth_request({
+  client,
+  body,
+}: DeviceAuthRequestInput): Promise<DeviceAuthRequestReturn> {
   const path = `/oauth2/device/auth`
   const qs = buildQuery({})
   const url = path + qs
@@ -47,9 +50,11 @@ export default async function device_auth_request(
       ''
   const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
+  headers['Content-Type'] = 'application/x-www-form-urlencoded'
   const fetchOptions: RequestInit = {
     method: 'POST',
     headers,
+    body: buildForm(body as unknown as Record<string, unknown>),
   }
   const _fetch = client?.fetch || fetch
   const response = await _fetch(fullUrl, fetchOptions)

--- a/src/api/oauth2/device_auth_request.ts
+++ b/src/api/oauth2/device_auth_request.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -23,7 +23,9 @@ type DeviceAuthRequestReturn = unknown
 export default async function device_auth_request(
   { client }: DeviceAuthRequestInput = {} as DeviceAuthRequestInput
 ): Promise<DeviceAuthRequestReturn> {
-  const url = `/oauth2/device/auth`
+  const path = `/oauth2/device/auth`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/device_auth_verify.ts
+++ b/src/api/oauth2/device_auth_verify.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
 
 interface DeviceAuthVerifyInput {
   client?: Client
-  app_name: string
+  app_name?: string
   user_code: string
 }
 
@@ -29,7 +29,9 @@ export default async function device_auth_verify({
   app_name,
   user_code,
 }: DeviceAuthVerifyInput): Promise<DeviceAuthVerifyReturn> {
-  const url = `/oauth2/device/verify?app_name=${app_name}&user_code=${user_code}`
+  const path = `/oauth2/device/verify`
+  const qs = buildQuery({ app_name: app_name, user_code: user_code })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/oauth2_provider_callback.ts
+++ b/src/api/oauth2/oauth2_provider_callback.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { AccountProvider } from '../../models.js'
@@ -6,10 +6,10 @@ import { AccountProvider } from '../../models.js'
 interface Oauth2ProviderCallbackInput {
   client?: Client
   provider: AccountProvider
-  code: string
-  id_token: string
-  state: string
-  user: string
+  code?: string
+  id_token?: string
+  state?: string
+  user?: string
 }
 
 type Oauth2ProviderCallbackReturn = unknown
@@ -36,7 +36,14 @@ export default async function oauth2_provider_callback({
   state,
   user,
 }: Oauth2ProviderCallbackInput): Promise<Oauth2ProviderCallbackReturn> {
-  const url = `/oauth2/provider/${provider}/callback?code=${code}&id_token=${id_token}&state=${state}&user=${user}`
+  const path = `/oauth2/provider/${provider}/callback`
+  const qs = buildQuery({
+    code: code,
+    id_token: id_token,
+    state: state,
+    user: user,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/oauth2_provider_callback_post.ts
+++ b/src/api/oauth2/oauth2_provider_callback_post.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { AccountProvider } from '../../models.js'
@@ -26,7 +26,9 @@ export default async function oauth2_provider_callback_post({
   client,
   provider,
 }: Oauth2ProviderCallbackPostInput): Promise<Oauth2ProviderCallbackPostReturn> {
-  const url = `/oauth2/provider/${provider}/callback`
+  const path = `/oauth2/provider/${provider}/callback`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/oauth2_provider_callback_post.ts
+++ b/src/api/oauth2/oauth2_provider_callback_post.ts
@@ -1,11 +1,12 @@
-import { Client, buildQuery } from '../../client.js'
+import { Client, buildQuery, buildForm } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
-import { AccountProvider } from '../../models.js'
+import { AccountProvider, AuthCallback } from '../../models.js'
 
 interface Oauth2ProviderCallbackPostInput {
   client?: Client
   provider: AccountProvider
+  body: AuthCallback
 }
 
 type Oauth2ProviderCallbackPostReturn = unknown
@@ -20,11 +21,13 @@ type Oauth2ProviderCallbackPostReturn = unknown
  * @param params Function parameters.
  * @property {Client} [client] Optional client with auth token.
  * @property {AccountProvider} provider The provider. (path)
+ * @property {AuthCallback} body Request body payload
  * @returns {Promise<Oauth2ProviderCallbackPostReturn>} Temporary Redirect
  */
 export default async function oauth2_provider_callback_post({
   client,
   provider,
+  body,
 }: Oauth2ProviderCallbackPostInput): Promise<Oauth2ProviderCallbackPostReturn> {
   const path = `/oauth2/provider/${provider}/callback`
   const qs = buildQuery({})
@@ -50,9 +53,11 @@ export default async function oauth2_provider_callback_post({
       ''
   const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
+  headers['Content-Type'] = 'application/x-www-form-urlencoded'
   const fetchOptions: RequestInit = {
     method: 'POST',
     headers,
+    body: buildForm(body as unknown as Record<string, unknown>),
   }
   const _fetch = client?.fetch || fetch
   const response = await _fetch(fullUrl, fetchOptions)

--- a/src/api/oauth2/oauth2_provider_consent.ts
+++ b/src/api/oauth2/oauth2_provider_consent.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { OAuth2ClientInfo, AccountProvider } from '../../models.js'
@@ -6,7 +6,7 @@ import { OAuth2ClientInfo, AccountProvider } from '../../models.js'
 interface Oauth2ProviderConsentInput {
   client?: Client
   provider: AccountProvider
-  callback_url: string
+  callback_url?: string
 }
 
 type Oauth2ProviderConsentReturn = OAuth2ClientInfo
@@ -29,7 +29,9 @@ export default async function oauth2_provider_consent({
   provider,
   callback_url,
 }: Oauth2ProviderConsentInput): Promise<Oauth2ProviderConsentReturn> {
-  const url = `/oauth2/provider/${provider}/consent?callback_url=${callback_url}`
+  const path = `/oauth2/provider/${provider}/consent`
+  const qs = buildQuery({ callback_url: callback_url })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/oauth2/oauth2_token_revoke.ts
+++ b/src/api/oauth2/oauth2_token_revoke.ts
@@ -1,10 +1,11 @@
-import { Client, buildQuery } from '../../client.js'
+import { Client, buildQuery, buildForm } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
-import {} from '../../models.js'
+import { TokenRevokeRequestForm } from '../../models.js'
 
 interface Oauth2TokenRevokeInput {
   client?: Client
+  body: TokenRevokeRequestForm
 }
 
 type Oauth2TokenRevokeReturn = unknown
@@ -18,11 +19,13 @@ type Oauth2TokenRevokeReturn = unknown
  *
  * @param params Function parameters.
  * @property {Client} [client] Optional client with auth token.
+ * @property {TokenRevokeRequestForm} body Request body payload
  * @returns {Promise<Oauth2TokenRevokeReturn>} Response payload.
  */
-export default async function oauth2_token_revoke(
-  { client }: Oauth2TokenRevokeInput = {} as Oauth2TokenRevokeInput
-): Promise<Oauth2TokenRevokeReturn> {
+export default async function oauth2_token_revoke({
+  client,
+  body,
+}: Oauth2TokenRevokeInput): Promise<Oauth2TokenRevokeReturn> {
   const path = `/oauth2/token/revoke`
   const qs = buildQuery({})
   const url = path + qs
@@ -47,9 +50,11 @@ export default async function oauth2_token_revoke(
       ''
   const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
+  headers['Content-Type'] = 'application/x-www-form-urlencoded'
   const fetchOptions: RequestInit = {
     method: 'POST',
     headers,
+    body: buildForm(body as unknown as Record<string, unknown>),
   }
   const _fetch = client?.fetch || fetch
   const response = await _fetch(fullUrl, fetchOptions)

--- a/src/api/oauth2/oauth2_token_revoke.ts
+++ b/src/api/oauth2/oauth2_token_revoke.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -23,7 +23,9 @@ type Oauth2TokenRevokeReturn = unknown
 export default async function oauth2_token_revoke(
   { client }: Oauth2TokenRevokeInput = {} as Oauth2TokenRevokeInput
 ): Promise<Oauth2TokenRevokeReturn> {
-  const url = `/oauth2/token/revoke`
+  const path = `/oauth2/token/revoke`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/create_org.ts
+++ b/src/api/orgs/create_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Org, OrgDetails } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function create_org({
   client,
   body,
 }: CreateOrgInput): Promise<CreateOrgReturn> {
-  const url = `/org`
+  const path = `/org`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/create_org_member.ts
+++ b/src/api/orgs/create_org_member.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { OrgMember, AddOrgMember } from '../../models.js'
@@ -36,7 +36,9 @@ export default async function create_org_member({
   client,
   body,
 }: CreateOrgMemberInput): Promise<CreateOrgMemberReturn> {
-  const url = `/org/members`
+  const path = `/org/members`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/create_org_saml_idp.ts
+++ b/src/api/orgs/create_org_saml_idp.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function create_org_saml_idp({
   client,
   body,
 }: CreateOrgSamlIdpInput): Promise<CreateOrgSamlIdpReturn> {
-  const url = `/org/saml/idp`
+  const path = `/org/saml/idp`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/delete_org.ts
+++ b/src/api/orgs/delete_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -27,7 +27,9 @@ type DeleteOrgReturn = void
 export default async function delete_org(
   { client }: DeleteOrgInput = {} as DeleteOrgInput
 ): Promise<DeleteOrgReturn> {
-  const url = `/org`
+  const path = `/org`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/delete_org_member.ts
+++ b/src/api/orgs/delete_org_member.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Uuid } from '../../models.js'
@@ -26,7 +26,9 @@ export default async function delete_org_member({
   client,
   user_id,
 }: DeleteOrgMemberInput): Promise<DeleteOrgMemberReturn> {
-  const url = `/org/members/${user_id}`
+  const path = `/org/members/${user_id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/delete_org_saml_idp.ts
+++ b/src/api/orgs/delete_org_saml_idp.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -23,7 +23,9 @@ type DeleteOrgSamlIdpReturn = void
 export default async function delete_org_saml_idp(
   { client }: DeleteOrgSamlIdpInput = {} as DeleteOrgSamlIdpInput
 ): Promise<DeleteOrgSamlIdpReturn> {
-  const url = `/org/saml/idp`
+  const path = `/org/saml/idp`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_any_org.ts
+++ b/src/api/orgs/get_any_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Org, Uuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_any_org({
   client,
   id,
 }: GetAnyOrgInput): Promise<GetAnyOrgReturn> {
-  const url = `/orgs/${id}`
+  const path = `/orgs/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_org.ts
+++ b/src/api/orgs/get_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Org } from '../../models.js'
@@ -25,7 +25,9 @@ type GetOrgReturn = Org
 export default async function get_org(
   { client }: GetOrgInput = {} as GetOrgInput
 ): Promise<GetOrgReturn> {
-  const url = `/org`
+  const path = `/org`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_org_member.ts
+++ b/src/api/orgs/get_org_member.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { OrgMember, Uuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_org_member({
   client,
   user_id,
 }: GetOrgMemberInput): Promise<GetOrgMemberReturn> {
-  const url = `/org/members/${user_id}`
+  const path = `/org/members/${user_id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_org_privacy_settings.ts
+++ b/src/api/orgs/get_org_privacy_settings.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PrivacySettings } from '../../models.js'
@@ -25,7 +25,9 @@ type GetOrgPrivacySettingsReturn = PrivacySettings
 export default async function get_org_privacy_settings(
   { client }: GetOrgPrivacySettingsInput = {} as GetOrgPrivacySettingsInput
 ): Promise<GetOrgPrivacySettingsReturn> {
-  const url = `/org/privacy`
+  const path = `/org/privacy`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_org_saml_idp.ts
+++ b/src/api/orgs/get_org_saml_idp.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { SamlIdentityProvider } from '../../models.js'
@@ -25,7 +25,9 @@ type GetOrgSamlIdpReturn = SamlIdentityProvider
 export default async function get_org_saml_idp(
   { client }: GetOrgSamlIdpInput = {} as GetOrgSamlIdpInput
 ): Promise<GetOrgSamlIdpReturn> {
-  const url = `/org/saml/idp`
+  const path = `/org/saml/idp`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_org_shortlinks.ts
+++ b/src/api/orgs/get_org_shortlinks.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface GetOrgShortlinksInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type GetOrgShortlinksReturn = ShortlinkResultsPage
@@ -39,7 +39,13 @@ export default async function get_org_shortlinks({
   page_token,
   sort_by,
 }: GetOrgShortlinksInput): Promise<GetOrgShortlinksReturn> {
-  const url = `/org/shortlinks?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/org/shortlinks`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/get_user_org.ts
+++ b/src/api/orgs/get_user_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UserOrgInfo } from '../../models.js'
@@ -27,7 +27,9 @@ type GetUserOrgReturn = UserOrgInfo
 export default async function get_user_org(
   { client }: GetUserOrgInput = {} as GetUserOrgInput
 ): Promise<GetUserOrgReturn> {
-  const url = `/user/org`
+  const path = `/user/org`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/list_org_members.ts
+++ b/src/api/orgs/list_org_members.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -11,10 +11,10 @@ import {
 
 interface ListOrgMembersInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
-  role: UserOrgRole
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
+  role?: UserOrgRole
 }
 
 type ListOrgMembersReturn = OrgMemberResultsPage
@@ -43,7 +43,14 @@ export default async function list_org_members({
   sort_by,
   role,
 }: ListOrgMembersInput): Promise<ListOrgMembersReturn> {
-  const url = `/org/members?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}&role=${role}`
+  const path = `/org/members`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+    role: role,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/list_orgs.ts
+++ b/src/api/orgs/list_orgs.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -6,9 +6,9 @@ import { OrgResultsPage, CreatedAtSortMode, Org } from '../../models.js'
 
 interface ListOrgsInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListOrgsReturn = OrgResultsPage
@@ -35,7 +35,13 @@ export default async function list_orgs({
   page_token,
   sort_by,
 }: ListOrgsInput): Promise<ListOrgsReturn> {
-  const url = `/orgs?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/orgs`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/update_enterprise_pricing_for_org.ts
+++ b/src/api/orgs/update_enterprise_pricing_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -35,7 +35,9 @@ export default async function update_enterprise_pricing_for_org({
   id,
   body,
 }: UpdateEnterprisePricingForOrgInput): Promise<UpdateEnterprisePricingForOrgReturn> {
-  const url = `/orgs/${id}/enterprise/pricing`
+  const path = `/orgs/${id}/enterprise/pricing`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/update_org.ts
+++ b/src/api/orgs/update_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Org, OrgDetails } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function update_org({
   client,
   body,
 }: UpdateOrgInput): Promise<UpdateOrgReturn> {
-  const url = `/org`
+  const path = `/org`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/update_org_member.ts
+++ b/src/api/orgs/update_org_member.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { OrgMember, Uuid, UpdateMemberToOrgBody } from '../../models.js'
@@ -31,7 +31,9 @@ export default async function update_org_member({
   user_id,
   body,
 }: UpdateOrgMemberInput): Promise<UpdateOrgMemberReturn> {
-  const url = `/org/members/${user_id}`
+  const path = `/org/members/${user_id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/update_org_privacy_settings.ts
+++ b/src/api/orgs/update_org_privacy_settings.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PrivacySettings } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function update_org_privacy_settings({
   client,
   body,
 }: UpdateOrgPrivacySettingsInput): Promise<UpdateOrgPrivacySettingsReturn> {
-  const url = `/org/privacy`
+  const path = `/org/privacy`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/orgs/update_org_saml_idp.ts
+++ b/src/api/orgs/update_org_saml_idp.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function update_org_saml_idp({
   client,
   body,
 }: UpdateOrgSamlIdpInput): Promise<UpdateOrgSamlIdpReturn> {
-  const url = `/org/saml/idp`
+  const path = `/org/saml/idp`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_org_subscription.ts
+++ b/src/api/payments/create_org_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function create_org_subscription({
   client,
   body,
 }: CreateOrgSubscriptionInput): Promise<CreateOrgSubscriptionReturn> {
-  const url = `/org/payment/subscriptions`
+  const path = `/org/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_payment_information_for_org.ts
+++ b/src/api/payments/create_payment_information_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer, BillingInfo } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function create_payment_information_for_org({
   client,
   body,
 }: CreatePaymentInformationForOrgInput): Promise<CreatePaymentInformationForOrgReturn> {
-  const url = `/org/payment`
+  const path = `/org/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_payment_information_for_user.ts
+++ b/src/api/payments/create_payment_information_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer, BillingInfo } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function create_payment_information_for_user({
   client,
   body,
 }: CreatePaymentInformationForUserInput): Promise<CreatePaymentInformationForUserReturn> {
-  const url = `/user/payment`
+  const path = `/user/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_payment_intent_for_org.ts
+++ b/src/api/payments/create_payment_intent_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PaymentIntent } from '../../models.js'
@@ -27,7 +27,9 @@ export default async function create_payment_intent_for_org(
     client,
   }: CreatePaymentIntentForOrgInput = {} as CreatePaymentIntentForOrgInput
 ): Promise<CreatePaymentIntentForOrgReturn> {
-  const url = `/org/payment/intent`
+  const path = `/org/payment/intent`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_payment_intent_for_user.ts
+++ b/src/api/payments/create_payment_intent_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PaymentIntent } from '../../models.js'
@@ -27,7 +27,9 @@ export default async function create_payment_intent_for_user(
     client,
   }: CreatePaymentIntentForUserInput = {} as CreatePaymentIntentForUserInput
 ): Promise<CreatePaymentIntentForUserReturn> {
-  const url = `/user/payment/intent`
+  const path = `/user/payment/intent`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/create_user_subscription.ts
+++ b/src/api/payments/create_user_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function create_user_subscription({
   client,
   body,
 }: CreateUserSubscriptionInput): Promise<CreateUserSubscriptionReturn> {
-  const url = `/user/payment/subscriptions`
+  const path = `/user/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/delete_payment_information_for_org.ts
+++ b/src/api/payments/delete_payment_information_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -27,7 +27,9 @@ export default async function delete_payment_information_for_org(
     client,
   }: DeletePaymentInformationForOrgInput = {} as DeletePaymentInformationForOrgInput
 ): Promise<DeletePaymentInformationForOrgReturn> {
-  const url = `/org/payment`
+  const path = `/org/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/delete_payment_information_for_user.ts
+++ b/src/api/payments/delete_payment_information_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -27,7 +27,9 @@ export default async function delete_payment_information_for_user(
     client,
   }: DeletePaymentInformationForUserInput = {} as DeletePaymentInformationForUserInput
 ): Promise<DeletePaymentInformationForUserReturn> {
-  const url = `/user/payment`
+  const path = `/user/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/delete_payment_method_for_org.ts
+++ b/src/api/payments/delete_payment_method_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -26,7 +26,9 @@ export default async function delete_payment_method_for_org({
   client,
   id,
 }: DeletePaymentMethodForOrgInput): Promise<DeletePaymentMethodForOrgReturn> {
-  const url = `/org/payment/methods/${id}`
+  const path = `/org/payment/methods/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/delete_payment_method_for_user.ts
+++ b/src/api/payments/delete_payment_method_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -26,7 +26,9 @@ export default async function delete_payment_method_for_user({
   client,
   id,
 }: DeletePaymentMethodForUserInput): Promise<DeletePaymentMethodForUserReturn> {
-  const url = `/user/payment/methods/${id}`
+  const path = `/user/payment/methods/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_org_subscription.ts
+++ b/src/api/payments/get_org_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ZooProductSubscriptions } from '../../models.js'
@@ -25,7 +25,9 @@ type GetOrgSubscriptionReturn = ZooProductSubscriptions
 export default async function get_org_subscription(
   { client }: GetOrgSubscriptionInput = {} as GetOrgSubscriptionInput
 ): Promise<GetOrgSubscriptionReturn> {
-  const url = `/org/payment/subscriptions`
+  const path = `/org/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_balance_for_any_org.ts
+++ b/src/api/payments/get_payment_balance_for_any_org.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CustomerBalance, Uuid } from '../../models.js'
 
 interface GetPaymentBalanceForAnyOrgInput {
   client?: Client
-  include_total_due: boolean
+  include_total_due?: boolean
   id: Uuid
 }
 
@@ -31,7 +31,9 @@ export default async function get_payment_balance_for_any_org({
   include_total_due,
   id,
 }: GetPaymentBalanceForAnyOrgInput): Promise<GetPaymentBalanceForAnyOrgReturn> {
-  const url = `/orgs/${id}/payment/balance?include_total_due=${include_total_due}`
+  const path = `/orgs/${id}/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_balance_for_any_user.ts
+++ b/src/api/payments/get_payment_balance_for_any_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CustomerBalance, UserIdentifier } from '../../models.js'
@@ -6,7 +6,7 @@ import { CustomerBalance, UserIdentifier } from '../../models.js'
 interface GetPaymentBalanceForAnyUserInput {
   client?: Client
   id: UserIdentifier
-  include_total_due: boolean
+  include_total_due?: boolean
 }
 
 type GetPaymentBalanceForAnyUserReturn = CustomerBalance
@@ -31,7 +31,9 @@ export default async function get_payment_balance_for_any_user({
   id,
   include_total_due,
 }: GetPaymentBalanceForAnyUserInput): Promise<GetPaymentBalanceForAnyUserReturn> {
-  const url = `/users/${id}/payment/balance?include_total_due=${include_total_due}`
+  const path = `/users/${id}/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_balance_for_org.ts
+++ b/src/api/payments/get_payment_balance_for_org.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CustomerBalance } from '../../models.js'
 
 interface GetPaymentBalanceForOrgInput {
   client?: Client
-  include_total_due: boolean
+  include_total_due?: boolean
 }
 
 type GetPaymentBalanceForOrgReturn = CustomerBalance
@@ -28,7 +28,9 @@ export default async function get_payment_balance_for_org({
   client,
   include_total_due,
 }: GetPaymentBalanceForOrgInput): Promise<GetPaymentBalanceForOrgReturn> {
-  const url = `/org/payment/balance?include_total_due=${include_total_due}`
+  const path = `/org/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_balance_for_user.ts
+++ b/src/api/payments/get_payment_balance_for_user.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CustomerBalance } from '../../models.js'
 
 interface GetPaymentBalanceForUserInput {
   client?: Client
-  include_total_due: boolean
+  include_total_due?: boolean
 }
 
 type GetPaymentBalanceForUserReturn = CustomerBalance
@@ -28,7 +28,9 @@ export default async function get_payment_balance_for_user({
   client,
   include_total_due,
 }: GetPaymentBalanceForUserInput): Promise<GetPaymentBalanceForUserReturn> {
-  const url = `/user/payment/balance?include_total_due=${include_total_due}`
+  const path = `/user/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_information_for_org.ts
+++ b/src/api/payments/get_payment_information_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer } from '../../models.js'
@@ -29,7 +29,9 @@ export default async function get_payment_information_for_org(
     client,
   }: GetPaymentInformationForOrgInput = {} as GetPaymentInformationForOrgInput
 ): Promise<GetPaymentInformationForOrgReturn> {
-  const url = `/org/payment`
+  const path = `/org/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_payment_information_for_user.ts
+++ b/src/api/payments/get_payment_information_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer } from '../../models.js'
@@ -29,7 +29,9 @@ export default async function get_payment_information_for_user(
     client,
   }: GetPaymentInformationForUserInput = {} as GetPaymentInformationForUserInput
 ): Promise<GetPaymentInformationForUserReturn> {
-  const url = `/user/payment`
+  const path = `/user/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/get_user_subscription.ts
+++ b/src/api/payments/get_user_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ZooProductSubscriptions } from '../../models.js'
@@ -25,7 +25,9 @@ type GetUserSubscriptionReturn = ZooProductSubscriptions
 export default async function get_user_subscription(
   { client }: GetUserSubscriptionInput = {} as GetUserSubscriptionInput
 ): Promise<GetUserSubscriptionReturn> {
-  const url = `/user/payment/subscriptions`
+  const path = `/user/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/list_invoices_for_org.ts
+++ b/src/api/payments/list_invoices_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Invoice } from '../../models.js'
@@ -25,7 +25,9 @@ type ListInvoicesForOrgReturn = Invoice[]
 export default async function list_invoices_for_org(
   { client }: ListInvoicesForOrgInput = {} as ListInvoicesForOrgInput
 ): Promise<ListInvoicesForOrgReturn> {
-  const url = `/org/payment/invoices`
+  const path = `/org/payment/invoices`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/list_invoices_for_user.ts
+++ b/src/api/payments/list_invoices_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Invoice } from '../../models.js'
@@ -25,7 +25,9 @@ type ListInvoicesForUserReturn = Invoice[]
 export default async function list_invoices_for_user(
   { client }: ListInvoicesForUserInput = {} as ListInvoicesForUserInput
 ): Promise<ListInvoicesForUserReturn> {
-  const url = `/user/payment/invoices`
+  const path = `/user/payment/invoices`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/list_payment_methods_for_org.ts
+++ b/src/api/payments/list_payment_methods_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PaymentMethod } from '../../models.js'
@@ -27,7 +27,9 @@ export default async function list_payment_methods_for_org(
     client,
   }: ListPaymentMethodsForOrgInput = {} as ListPaymentMethodsForOrgInput
 ): Promise<ListPaymentMethodsForOrgReturn> {
-  const url = `/org/payment/methods`
+  const path = `/org/payment/methods`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/list_payment_methods_for_user.ts
+++ b/src/api/payments/list_payment_methods_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PaymentMethod } from '../../models.js'
@@ -27,7 +27,9 @@ export default async function list_payment_methods_for_user(
     client,
   }: ListPaymentMethodsForUserInput = {} as ListPaymentMethodsForUserInput
 ): Promise<ListPaymentMethodsForUserReturn> {
-  const url = `/user/payment/methods`
+  const path = `/user/payment/methods`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_org_subscription.ts
+++ b/src/api/payments/update_org_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function update_org_subscription({
   client,
   body,
 }: UpdateOrgSubscriptionInput): Promise<UpdateOrgSubscriptionReturn> {
-  const url = `/org/payment/subscriptions`
+  const path = `/org/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_payment_balance_for_any_org.ts
+++ b/src/api/payments/update_payment_balance_for_any_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CustomerBalance, Uuid, UpdatePaymentBalance } from '../../models.js'
@@ -6,7 +6,7 @@ import { CustomerBalance, Uuid, UpdatePaymentBalance } from '../../models.js'
 interface UpdatePaymentBalanceForAnyOrgInput {
   client?: Client
   id: Uuid
-  include_total_due: boolean
+  include_total_due?: boolean
   body: UpdatePaymentBalance
 }
 
@@ -34,7 +34,9 @@ export default async function update_payment_balance_for_any_org({
   include_total_due,
   body,
 }: UpdatePaymentBalanceForAnyOrgInput): Promise<UpdatePaymentBalanceForAnyOrgReturn> {
-  const url = `/orgs/${id}/payment/balance?include_total_due=${include_total_due}`
+  const path = `/orgs/${id}/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_payment_balance_for_any_user.ts
+++ b/src/api/payments/update_payment_balance_for_any_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -10,7 +10,7 @@ import {
 interface UpdatePaymentBalanceForAnyUserInput {
   client?: Client
   id: UserIdentifier
-  include_total_due: boolean
+  include_total_due?: boolean
   body: UpdatePaymentBalance
 }
 
@@ -38,7 +38,9 @@ export default async function update_payment_balance_for_any_user({
   include_total_due,
   body,
 }: UpdatePaymentBalanceForAnyUserInput): Promise<UpdatePaymentBalanceForAnyUserReturn> {
-  const url = `/users/${id}/payment/balance?include_total_due=${include_total_due}`
+  const path = `/users/${id}/payment/balance`
+  const qs = buildQuery({ include_total_due: include_total_due })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_payment_information_for_org.ts
+++ b/src/api/payments/update_payment_information_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer, BillingInfo } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function update_payment_information_for_org({
   client,
   body,
 }: UpdatePaymentInformationForOrgInput): Promise<UpdatePaymentInformationForOrgReturn> {
-  const url = `/org/payment`
+  const path = `/org/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_payment_information_for_user.ts
+++ b/src/api/payments/update_payment_information_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Customer, BillingInfo } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function update_payment_information_for_user({
   client,
   body,
 }: UpdatePaymentInformationForUserInput): Promise<UpdatePaymentInformationForUserReturn> {
-  const url = `/user/payment`
+  const path = `/user/payment`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/update_user_subscription.ts
+++ b/src/api/payments/update_user_subscription.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function update_user_subscription({
   client,
   body,
 }: UpdateUserSubscriptionInput): Promise<UpdateUserSubscriptionReturn> {
-  const url = `/user/payment/subscriptions`
+  const path = `/user/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/validate_customer_tax_information_for_org.ts
+++ b/src/api/payments/validate_customer_tax_information_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -25,7 +25,9 @@ export default async function validate_customer_tax_information_for_org(
     client,
   }: ValidateCustomerTaxInformationForOrgInput = {} as ValidateCustomerTaxInformationForOrgInput
 ): Promise<ValidateCustomerTaxInformationForOrgReturn> {
-  const url = `/org/payment/tax`
+  const path = `/org/payment/tax`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/payments/validate_customer_tax_information_for_user.ts
+++ b/src/api/payments/validate_customer_tax_information_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -25,7 +25,9 @@ export default async function validate_customer_tax_information_for_user(
     client,
   }: ValidateCustomerTaxInformationForUserInput = {} as ValidateCustomerTaxInformationForUserInput
 ): Promise<ValidateCustomerTaxInformationForUserReturn> {
-  const url = `/user/payment/tax`
+  const path = `/user/payment/tax`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/service-accounts/create_service_account_for_org.ts
+++ b/src/api/service-accounts/create_service_account_for_org.ts
@@ -1,11 +1,11 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ServiceAccount } from '../../models.js'
 
 interface CreateServiceAccountForOrgInput {
   client?: Client
-  label: string
+  label?: string
 }
 
 type CreateServiceAccountForOrgReturn = ServiceAccount
@@ -28,7 +28,9 @@ export default async function create_service_account_for_org({
   client,
   label,
 }: CreateServiceAccountForOrgInput): Promise<CreateServiceAccountForOrgReturn> {
-  const url = `/org/service-accounts?label=${label}`
+  const path = `/org/service-accounts`
+  const qs = buildQuery({ label: label })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/service-accounts/delete_service_account_for_org.ts
+++ b/src/api/service-accounts/delete_service_account_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ServiceAccountUuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function delete_service_account_for_org({
   client,
   token,
 }: DeleteServiceAccountForOrgInput): Promise<DeleteServiceAccountForOrgReturn> {
-  const url = `/org/service-accounts/${token}`
+  const path = `/org/service-accounts/${token}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/service-accounts/get_service_account_for_org.ts
+++ b/src/api/service-accounts/get_service_account_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ServiceAccount, ServiceAccountUuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_service_account_for_org({
   client,
   token,
 }: GetServiceAccountForOrgInput): Promise<GetServiceAccountForOrgReturn> {
-  const url = `/org/service-accounts/${token}`
+  const path = `/org/service-accounts/${token}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/service-accounts/list_service_accounts_for_org.ts
+++ b/src/api/service-accounts/list_service_accounts_for_org.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListServiceAccountsForOrgInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListServiceAccountsForOrgReturn = ServiceAccountResultsPage
@@ -41,7 +41,13 @@ export default async function list_service_accounts_for_org({
   page_token,
   sort_by,
 }: ListServiceAccountsForOrgInput): Promise<ListServiceAccountsForOrgReturn> {
-  const url = `/org/service-accounts?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/org/service-accounts`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/store/create_store_coupon.ts
+++ b/src/api/store/create_store_coupon.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { DiscountCode, StoreCouponParams } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function create_store_coupon({
   client,
   body,
 }: CreateStoreCouponInput): Promise<CreateStoreCouponReturn> {
-  const url = `/store/coupon`
+  const path = `/store/coupon`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_angle_unit_conversion.ts
+++ b/src/api/unit/get_angle_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitAngleConversion, UnitAngle } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_angle_unit_conversion({
   output_unit,
   value,
 }: GetAngleUnitConversionInput): Promise<GetAngleUnitConversionReturn> {
-  const url = `/unit/conversion/angle/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/angle/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_area_unit_conversion.ts
+++ b/src/api/unit/get_area_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitAreaConversion, UnitArea } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_area_unit_conversion({
   output_unit,
   value,
 }: GetAreaUnitConversionInput): Promise<GetAreaUnitConversionReturn> {
-  const url = `/unit/conversion/area/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/area/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_current_unit_conversion.ts
+++ b/src/api/unit/get_current_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitCurrentConversion, UnitCurrent } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_current_unit_conversion({
   output_unit,
   value,
 }: GetCurrentUnitConversionInput): Promise<GetCurrentUnitConversionReturn> {
-  const url = `/unit/conversion/current/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/current/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_energy_unit_conversion.ts
+++ b/src/api/unit/get_energy_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitEnergyConversion, UnitEnergy } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_energy_unit_conversion({
   output_unit,
   value,
 }: GetEnergyUnitConversionInput): Promise<GetEnergyUnitConversionReturn> {
-  const url = `/unit/conversion/energy/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/energy/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_force_unit_conversion.ts
+++ b/src/api/unit/get_force_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitForceConversion, UnitForce } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_force_unit_conversion({
   output_unit,
   value,
 }: GetForceUnitConversionInput): Promise<GetForceUnitConversionReturn> {
-  const url = `/unit/conversion/force/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/force/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_frequency_unit_conversion.ts
+++ b/src/api/unit/get_frequency_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitFrequencyConversion, UnitFrequency } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_frequency_unit_conversion({
   output_unit,
   value,
 }: GetFrequencyUnitConversionInput): Promise<GetFrequencyUnitConversionReturn> {
-  const url = `/unit/conversion/frequency/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/frequency/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_length_unit_conversion.ts
+++ b/src/api/unit/get_length_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitLengthConversion, UnitLength } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_length_unit_conversion({
   output_unit,
   value,
 }: GetLengthUnitConversionInput): Promise<GetLengthUnitConversionReturn> {
-  const url = `/unit/conversion/length/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/length/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_mass_unit_conversion.ts
+++ b/src/api/unit/get_mass_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitMassConversion, UnitMass } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_mass_unit_conversion({
   output_unit,
   value,
 }: GetMassUnitConversionInput): Promise<GetMassUnitConversionReturn> {
-  const url = `/unit/conversion/mass/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/mass/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_power_unit_conversion.ts
+++ b/src/api/unit/get_power_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitPowerConversion, UnitPower } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_power_unit_conversion({
   output_unit,
   value,
 }: GetPowerUnitConversionInput): Promise<GetPowerUnitConversionReturn> {
-  const url = `/unit/conversion/power/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/power/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_pressure_unit_conversion.ts
+++ b/src/api/unit/get_pressure_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitPressureConversion, UnitPressure } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_pressure_unit_conversion({
   output_unit,
   value,
 }: GetPressureUnitConversionInput): Promise<GetPressureUnitConversionReturn> {
-  const url = `/unit/conversion/pressure/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/pressure/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_temperature_unit_conversion.ts
+++ b/src/api/unit/get_temperature_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitTemperatureConversion, UnitTemperature } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_temperature_unit_conversion({
   output_unit,
   value,
 }: GetTemperatureUnitConversionInput): Promise<GetTemperatureUnitConversionReturn> {
-  const url = `/unit/conversion/temperature/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/temperature/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_torque_unit_conversion.ts
+++ b/src/api/unit/get_torque_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitTorqueConversion, UnitTorque } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_torque_unit_conversion({
   output_unit,
   value,
 }: GetTorqueUnitConversionInput): Promise<GetTorqueUnitConversionReturn> {
-  const url = `/unit/conversion/torque/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/torque/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/unit/get_volume_unit_conversion.ts
+++ b/src/api/unit/get_volume_unit_conversion.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UnitVolumeConversion, UnitVolume } from '../../models.js'
@@ -34,7 +34,9 @@ export default async function get_volume_unit_conversion({
   output_unit,
   value,
 }: GetVolumeUnitConversionInput): Promise<GetVolumeUnitConversionReturn> {
-  const url = `/unit/conversion/volume/${input_unit}/${output_unit}?value=${value}`
+  const path = `/unit/conversion/volume/${input_unit}/${output_unit}`
+  const qs = buildQuery({ value: value })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/create_user_shortlink.ts
+++ b/src/api/users/create_user_shortlink.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -31,7 +31,9 @@ export default async function create_user_shortlink({
   client,
   body,
 }: CreateUserShortlinkInput): Promise<CreateUserShortlinkReturn> {
-  const url = `/user/shortlinks`
+  const path = `/user/shortlinks`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/delete_user_self.ts
+++ b/src/api/users/delete_user_self.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -25,7 +25,9 @@ type DeleteUserSelfReturn = void
 export default async function delete_user_self(
   { client }: DeleteUserSelfInput = {} as DeleteUserSelfInput
 ): Promise<DeleteUserSelfReturn> {
-  const url = `/user`
+  const path = `/user`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/delete_user_shortlink.ts
+++ b/src/api/users/delete_user_shortlink.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {} from '../../models.js'
@@ -26,7 +26,9 @@ export default async function delete_user_shortlink({
   client,
   key,
 }: DeleteUserShortlinkInput): Promise<DeleteUserShortlinkReturn> {
-  const url = `/user/shortlinks/${key}`
+  const path = `/user/shortlinks/${key}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_oauth2_providers_for_user.ts
+++ b/src/api/users/get_oauth2_providers_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { AccountProvider } from '../../models.js'
@@ -29,7 +29,9 @@ export default async function get_oauth2_providers_for_user(
     client,
   }: GetOauth2ProvidersForUserInput = {} as GetOauth2ProvidersForUserInput
 ): Promise<GetOauth2ProvidersForUserReturn> {
-  const url = `/user/oauth2/providers`
+  const path = `/user/oauth2/providers`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_session_for_user.ts
+++ b/src/api/users/get_session_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Session, SessionUuid } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function get_session_for_user({
   client,
   token,
 }: GetSessionForUserInput): Promise<GetSessionForUserReturn> {
-  const url = `/user/session/${token}`
+  const path = `/user/session/${token}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user.ts
+++ b/src/api/users/get_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { User, UserIdentifier } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function get_user({
   client,
   id,
 }: GetUserInput): Promise<GetUserReturn> {
-  const url = `/users/${id}`
+  const path = `/users/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user_extended.ts
+++ b/src/api/users/get_user_extended.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ExtendedUser, UserIdentifier } from '../../models.js'
@@ -30,7 +30,9 @@ export default async function get_user_extended({
   client,
   id,
 }: GetUserExtendedInput): Promise<GetUserExtendedReturn> {
-  const url = `/users-extended/${id}`
+  const path = `/users-extended/${id}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user_privacy_settings.ts
+++ b/src/api/users/get_user_privacy_settings.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PrivacySettings } from '../../models.js'
@@ -25,7 +25,9 @@ type GetUserPrivacySettingsReturn = PrivacySettings
 export default async function get_user_privacy_settings(
   { client }: GetUserPrivacySettingsInput = {} as GetUserPrivacySettingsInput
 ): Promise<GetUserPrivacySettingsReturn> {
-  const url = `/user/privacy`
+  const path = `/user/privacy`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user_self.ts
+++ b/src/api/users/get_user_self.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { User } from '../../models.js'
@@ -27,7 +27,9 @@ type GetUserSelfReturn = User
 export default async function get_user_self(
   { client }: GetUserSelfInput = {} as GetUserSelfInput
 ): Promise<GetUserSelfReturn> {
-  const url = `/user`
+  const path = `/user`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user_self_extended.ts
+++ b/src/api/users/get_user_self_extended.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { ExtendedUser } from '../../models.js'
@@ -27,7 +27,9 @@ type GetUserSelfExtendedReturn = ExtendedUser
 export default async function get_user_self_extended(
   { client }: GetUserSelfExtendedInput = {} as GetUserSelfExtendedInput
 ): Promise<GetUserSelfExtendedReturn> {
-  const url = `/user/extended`
+  const path = `/user/extended`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/get_user_shortlinks.ts
+++ b/src/api/users/get_user_shortlinks.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface GetUserShortlinksInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type GetUserShortlinksReturn = ShortlinkResultsPage
@@ -39,7 +39,13 @@ export default async function get_user_shortlinks({
   page_token,
   sort_by,
 }: GetUserShortlinksInput): Promise<GetUserShortlinksReturn> {
-  const url = `/user/shortlinks?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/user/shortlinks`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/list_users.ts
+++ b/src/api/users/list_users.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -6,9 +6,9 @@ import { UserResultsPage, CreatedAtSortMode, User } from '../../models.js'
 
 interface ListUsersInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListUsersReturn = UserResultsPage
@@ -35,7 +35,13 @@ export default async function list_users({
   page_token,
   sort_by,
 }: ListUsersInput): Promise<ListUsersReturn> {
-  const url = `/users?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/users`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/list_users_extended.ts
+++ b/src/api/users/list_users_extended.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 import { Pager, createPager } from '../../pagination.js'
 
@@ -10,9 +10,9 @@ import {
 
 interface ListUsersExtendedInput {
   client?: Client
-  limit: number
-  page_token: string
-  sort_by: CreatedAtSortMode
+  limit?: number
+  page_token?: string
+  sort_by?: CreatedAtSortMode
 }
 
 type ListUsersExtendedReturn = ExtendedUserResultsPage
@@ -39,7 +39,13 @@ export default async function list_users_extended({
   page_token,
   sort_by,
 }: ListUsersExtendedInput): Promise<ListUsersExtendedReturn> {
-  const url = `/users-extended?limit=${limit}&page_token=${page_token}&sort_by=${sort_by}`
+  const path = `/users-extended`
+  const qs = buildQuery({
+    limit: limit,
+    page_token: page_token,
+    sort_by: sort_by,
+  })
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/patch_user_crm.ts
+++ b/src/api/users/patch_user_crm.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { CrmData } from '../../models.js'
@@ -24,7 +24,9 @@ export default async function patch_user_crm({
   client,
   body,
 }: PatchUserCrmInput): Promise<PatchUserCrmReturn> {
-  const url = `/user/crm`
+  const path = `/user/crm`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/put_public_form.ts
+++ b/src/api/users/put_public_form.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { InquiryForm } from '../../models.js'
@@ -26,7 +26,9 @@ export default async function put_public_form({
   client,
   body,
 }: PutPublicFormInput): Promise<PutPublicFormReturn> {
-  const url = `/website/form`
+  const path = `/website/form`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/put_public_subscribe.ts
+++ b/src/api/users/put_public_subscribe.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { Subscribe } from '../../models.js'
@@ -24,7 +24,9 @@ export default async function put_public_subscribe({
   client,
   body,
 }: PutPublicSubscribeInput): Promise<PutPublicSubscribeReturn> {
-  const url = `/website/subscribe`
+  const path = `/website/subscribe`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/put_user_form_self.ts
+++ b/src/api/users/put_user_form_self.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { InquiryForm } from '../../models.js'
@@ -26,7 +26,9 @@ export default async function put_user_form_self({
   client,
   body,
 }: PutUserFormSelfInput): Promise<PutUserFormSelfReturn> {
-  const url = `/user/form`
+  const path = `/user/form`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/update_subscription_for_user.ts
+++ b/src/api/users/update_subscription_for_user.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import {
@@ -35,7 +35,9 @@ export default async function update_subscription_for_user({
   id,
   body,
 }: UpdateSubscriptionForUserInput): Promise<UpdateSubscriptionForUserReturn> {
-  const url = `/users/${id}/payment/subscriptions`
+  const path = `/users/${id}/payment/subscriptions`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/update_user_privacy_settings.ts
+++ b/src/api/users/update_user_privacy_settings.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { PrivacySettings } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function update_user_privacy_settings({
   client,
   body,
 }: UpdateUserPrivacySettingsInput): Promise<UpdateUserPrivacySettingsReturn> {
-  const url = `/user/privacy`
+  const path = `/user/privacy`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/update_user_self.ts
+++ b/src/api/users/update_user_self.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { User, UpdateUser } from '../../models.js'
@@ -28,7 +28,9 @@ export default async function update_user_self({
   client,
   body,
 }: UpdateUserSelfInput): Promise<UpdateUserSelfReturn> {
-  const url = `/user`
+  const path = `/user`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/api/users/update_user_shortlink.ts
+++ b/src/api/users/update_user_shortlink.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../client.js'
+import { Client, buildQuery } from '../../client.js'
 import { throwIfNotOk } from '../../errors.js'
 
 import { UpdateShortlinkRequest } from '../../models.js'
@@ -31,7 +31,9 @@ export default async function update_user_shortlink({
   key,
   body,
 }: UpdateUserShortlinkInput): Promise<UpdateUserShortlinkReturn> {
-  const url = `/user/shortlinks/${key}`
+  const path = `/user/shortlinks/${key}`
+  const qs = buildQuery({})
+  const url = path + qs
   // Backwards compatible for the BASE_URL env variable
   // That used to exist in only this lib, ZOO_HOST exists in the all the other
   // sdks and the CLI.

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,6 +57,23 @@ export function buildQuery(params: Record<string, unknown>): string {
   return qs ? `?${qs}` : ''
 }
 
+/**
+ * Build an application/x-www-form-urlencoded body from a params map,
+ * skipping undefined and expanding arrays as repeated keys.
+ */
+export function buildForm(params: Record<string, unknown>): URLSearchParams {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value === undefined) continue
+    if (Array.isArray(value)) {
+      for (const v of value) search.append(key, String(v))
+    } else {
+      search.append(key, String(value))
+    }
+  }
+  return search
+}
+
 // On Windows + Node, load system CAs so TLS works behind enterprise roots.
 // This is a no-op on non-Windows platforms and in browsers.
 try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,24 @@ export class Client {
   }
 }
 
+/**
+ * Build a URL query string from a map of params, skipping undefined values.
+ * Arrays append multiple entries with the same key. Returns '' when empty.
+ */
+export function buildQuery(params: Record<string, unknown>): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue
+    if (Array.isArray(value)) {
+      for (const v of value) search.append(key, String(v))
+    } else {
+      search.append(key, String(value))
+    }
+  }
+  const qs = search.toString()
+  return qs ? `?${qs}` : ''
+}
+
 // On Windows + Node, load system CAs so TLS works behind enterprise roots.
 // This is a no-op on non-Windows platforms and in browsers.
 try {


### PR DESCRIPTION
- Switch generator to buildQuery, omit undefined query params; path params required, others optional
- Update REST, multipart, and WS templates; add pagination test; bump package to 3.0.1