### PR TITLE
fix(multipart): let FormData set Content-Type boundary, not us (shocker)

### DIFF
--- a/gen/templates/multipart.hbs
+++ b/gen/templates/multipart.hbs
@@ -30,9 +30,7 @@ export default async function {{functionName}}(
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       '';
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  };
+  const headers: Record<string, string> = {};
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`;
 
   const formData = new FormData();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/api/file/create_file_conversion_options.ts
+++ b/src/api/file/create_file_conversion_options.ts
@@ -58,9 +58,7 @@ export default async function create_file_conversion_options({
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       ''
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  }
+  const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
 
   const formData = new FormData()

--- a/src/api/meta/create_debug_uploads.ts
+++ b/src/api/meta/create_debug_uploads.ts
@@ -49,9 +49,7 @@ export default async function create_debug_uploads({
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       ''
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  }
+  const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
 
   const formData = new FormData()

--- a/src/api/meta/create_event.ts
+++ b/src/api/meta/create_event.ts
@@ -52,9 +52,7 @@ export default async function create_event({
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       ''
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  }
+  const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
 
   const formData = new FormData()

--- a/src/api/ml/create_proprietary_to_kcl.ts
+++ b/src/api/ml/create_proprietary_to_kcl.ts
@@ -58,9 +58,7 @@ export default async function create_proprietary_to_kcl({
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       ''
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  }
+  const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
 
   const formData = new FormData()

--- a/src/api/ml/create_text_to_cad_multi_file_iteration.ts
+++ b/src/api/ml/create_text_to_cad_multi_file_iteration.ts
@@ -65,9 +65,7 @@ export default async function create_text_to_cad_multi_file_iteration({
       process.env.KITTYCAD_API_TOKEN ||
       process.env.ZOO_API_TOKEN ||
       ''
-  const headers: Record<string, string> = {
-    'Content-Type': 'multipart/form-data',
-  }
+  const headers: Record<string, string> = {}
   if (kittycadToken) headers.Authorization = `Bearer ${kittycadToken}`
 
   const formData = new FormData()


### PR DESCRIPTION
- Remove manual multipart Content-Type header; let FormData set boundary
- Fixes broken uploads in browser and Node; Authorization header unchanged