### PR TITLE
fix(gen): stop flattening map responses into arrays, Morty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/api/meta/get_pricing_subscriptions.ts
+++ b/src/api/meta/get_pricing_subscriptions.ts
@@ -7,7 +7,7 @@ interface GetPricingSubscriptionsInput {
   client?: Client
 }
 
-type GetPricingSubscriptionsReturn = ZooProductSubscription[]
+type GetPricingSubscriptionsReturn = Record<string, ZooProductSubscription[]>
 
 /**
  * Get the pricing for our subscriptions.
@@ -20,7 +20,7 @@ type GetPricingSubscriptionsReturn = ZooProductSubscription[]
  * @property {Client} [client] Optional client with auth token.
  * @returns {Promise<GetPricingSubscriptionsReturn>} successful operation
  *
- * Possible return types: ZooProductSubscription[]
+ * Possible return types: ZooProductSubscription
  */
 export default async function get_pricing_subscriptions(
   { client }: GetPricingSubscriptionsInput = {} as GetPricingSubscriptionsInput


### PR DESCRIPTION
- Preserve additionalProperties as Record<string, T or T[]>, import inner model types
- Update meta.get_pricing_subscriptions to return a map of arrays, bump version to 3.0.4

BREAKING CHANGE: get_pricing_subscriptions now returns Record<string, ZooProductSubscription[]>, not ZooProductSubscription[].