### PR TITLE
Remove old ass fetch polyfill, don't encourage old ass nodejs usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "bson": "^7.1.1",
-        "cross-fetch": "^4.0.0",
         "openapi-types": "^12.0.0",
         "ts-node": "^10.9.1",
         "tslib": "~2.8",
@@ -3920,14 +3919,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5192,25 +5183,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
@@ -6028,11 +6000,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -6481,20 +6448,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^7.1.1",
-    "cross-fetch": "^4.0.0",
     "openapi-types": "^12.0.0",
     "ts-node": "^10.9.1",
     "tslib": "~2.8",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,22 +1,3 @@
-// Load fetch polyfill dynamically only when needed (older Node),
-// and avoid bundlers pulling it into browser builds.
-try {
-  if (
-    typeof fetch === 'undefined' &&
-    typeof process !== 'undefined' &&
-    (process as unknown as NodeJS.Process).versions?.node
-  ) {
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
-    const din = new Function('m', 'return import(m)') as (
-      m: string
-    ) => Promise<unknown>
-    // Fire and forget; Node 18+ already has fetch so this is mostly a no-op.
-    void din('cross-fetch/polyfill').catch(() => {})
-  }
-} catch {
-  // ignore if not available
-}
-
 export interface ClientOptions {
   token?: string
   baseUrl?: string


### PR DESCRIPTION
One of many QoL PRs coming.

We should not encourage old NodeJS versions to be run - they are surely full of unpatched security holes.

`fetch` was officially introduced into NodeJS v18 on April 19, 2022, so it's been almost 4 years.

Consumers who want earlier should polyfill their global and take responsibility of this.