### PR TITLE
Use exact kcl-wasm-lib version for blob compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,9 @@ It triggers a bot to commit the new specification to this repository.
 **Every commit to main is published to NPM. Make sure to bump the version before merging any PR!**
 
 Before merging your PR run and commit the result of `npm version patch --no-git-tag-version`.
+
+## Maintainer Notes
+
+The `@kittycad/kcl-wasm-lib` dependency MUST BE THE EXACT VERSION, DO NOT
+CHANGE TO USING `^x.y.z` notation!
+

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ AN EXPLANATION BEHIND THE DERIVATION PROCESS!**
 
 ### [Full documentation here](https://zoo.dev/docs/api?lang=typescript)
 
-Simple example below.
-
 ### Install
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.9",
+      "version": "4.0.10",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.8",
       "license": "MIT",
       "dependencies": {
-        "@kittycad/kcl-wasm-lib": "^0.1.141",
+        "@kittycad/kcl-wasm-lib": "0.1.141",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",
         "cross-fetch": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@msgpack/msgpack": "^3.1.3",
     "bson": "^7.1.1",
     "cross-fetch": "^4.0.0",
-    "@kittycad/kcl-wasm-lib": "^0.1.141",
+    "@kittycad/kcl-wasm-lib": "0.1.141",
     "openapi-types": "^12.0.0",
     "rollup-plugin-web-worker-loader": "^1.7.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
I hit the beautiful issue of generated wasm blobs & their sibling js needing to be the exact version. `^0.1.114` is not the same as `0.1.114`. _Ugh_. Understandable though. This is necessary so `@kittycad/lib` does _not_ need to pack the wasm blob into itself and the npm packaging system can continue to take care of it.