### PR TITLE
Expose commands going out too as well as responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.11",
+      "version": "4.0.12",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.12",
+      "version": "4.0.13",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/worker-webrtc.ts
+++ b/src/worker-webrtc.ts
@@ -99,6 +99,11 @@ const engineCommandManagerLite = {
     commandStr: string,
     _idToRangeStr: string
   ): Promise<Uint8Array | undefined> {
+    postMessage({
+      from: 'websocket',
+      payload: { type: 'message', data: commandStr },
+    })
+    
     zooModelingCommandsWs?.send(commandStr)
 
     return new Promise((resolve) => {

--- a/src/worker-webrtc.ts
+++ b/src/worker-webrtc.ts
@@ -103,7 +103,7 @@ const engineCommandManagerLite = {
       from: 'websocket',
       payload: { type: 'message', data: commandStr },
     })
-    
+
     zooModelingCommandsWs?.send(commandStr)
 
     return new Promise((resolve) => {


### PR DESCRIPTION
Was only returning responses. For application developers they sometimes need to know the data going out to be able to revert some operations.