### PR TITLE
Pass-through individual raw websocket responses on single sends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.19",
+      "version": "4.0.20",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.18",
+  "version": "4.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.18",
+      "version": "4.0.19",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.18",
+  "version": "4.0.19",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -1,7 +1,9 @@
 import { Client } from './client'
 import ModelingCommandsWs from './api/modeling/modeling_commands_ws'
-import { OkWebSocketResponseData } from './models'
+import { OkWebSocketResponseData, SuccessWebSocketResponse, FailureWebSocketResponse } from './models'
 import WorkerWebRTC from 'web-worker:./worker-webrtc.ts'
+
+type ExpectedWebSocketResponse = FailureWebSocketResponse | SuccessWebSocketResponse | Error
 
 // Based on human interaction speeds.
 const throttle = (
@@ -205,17 +207,18 @@ export class WebRTC extends EventTarget {
         this.workerWebRTC,
         'message'
       ),
-      submit: (kclStr: string) =>
+      submit: (kclStr: string): Promise<ExpectedWebSocketResponse> =>
         new Promise((resolve) => {
           const onMessage = (ev: MessageEvent<WorkerMessage>) => {
             const msg = ev.data
             if (
               'from' in msg &&
+              // It's initiated from the wasm, but the very very root is the websocket.
               msg.from === 'wasm' &&
               msg.payload.type === 'execute'
             ) {
               this.workerWebRTC.removeEventListener('message', onMessage)
-              resolve(msg.payload.data)
+              resolve(msg.payload.data as ExpectedWebSocketResponse)
             }
           }
           this.workerWebRTC.addEventListener('message', onMessage)
@@ -571,13 +574,25 @@ export class WebRTC extends EventTarget {
   }
 
   // In the future this could be over WebRTC channels.
-  send(...args: Parameters<WebSocket['send']>) {
-    this.workerWebRTC.postMessage({
-      to: 'websocket',
-      payload: {
-        type: 'send',
-        data: args,
-      },
+  send(...args: Parameters<WebSocket['send']>): Promise<ExpectedWebSocketResponse> {
+    return new Promise((resolve) => {
+      const onMessage = (ev: MessageEvent<WorkerMessage>) => {
+        const msg = ev.data
+        if ('from' in msg && msg.from === 'websocket') {
+          this.workerWebRTC.removeEventListener('message', onMessage)
+          resolve(msg.payload.data as ExpectedWebSocketResponse)
+        }
+      }
+
+      this.workerWebRTC.addEventListener('message', onMessage)
+
+      this.workerWebRTC.postMessage({
+        to: 'websocket',
+        payload: {
+          type: 'send',
+          data: args,
+        },
+      })
     })
   }
 }

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -1,9 +1,16 @@
 import { Client } from './client'
 import ModelingCommandsWs from './api/modeling/modeling_commands_ws'
-import { OkWebSocketResponseData, SuccessWebSocketResponse, FailureWebSocketResponse } from './models'
+import {
+  OkWebSocketResponseData,
+  SuccessWebSocketResponse,
+  FailureWebSocketResponse,
+} from './models'
 import WorkerWebRTC from 'web-worker:./worker-webrtc.ts'
 
-type ExpectedWebSocketResponse = FailureWebSocketResponse | SuccessWebSocketResponse | Error
+type ExpectedWebSocketResponse =
+  | FailureWebSocketResponse
+  | SuccessWebSocketResponse
+  | Error
 
 // Based on human interaction speeds.
 const throttle = (
@@ -574,7 +581,9 @@ export class WebRTC extends EventTarget {
   }
 
   // In the future this could be over WebRTC channels.
-  send(...args: Parameters<WebSocket['send']>): Promise<ExpectedWebSocketResponse> {
+  send(
+    ...args: Parameters<WebSocket['send']>
+  ): Promise<ExpectedWebSocketResponse> {
     return new Promise((resolve) => {
       const onMessage = (ev: MessageEvent<WorkerMessage>) => {
         const msg = ev.data


### PR DESCRIPTION
Right now the only way for consumers to catch individual responses from individual outgoing requests is to hook into an executor() addEventListener - which is wrong, since the purpose of that is to read in responses from a KCL execution.