### PR TITLE
Expose being able to select a different KCL entry point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.20",
+      "version": "4.0.21",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.143",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.21",
+      "version": "4.0.22",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.143",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -214,7 +214,10 @@ export class WebRTC extends EventTarget {
         this.workerWebRTC,
         'message'
       ),
-      submit: (kclStr: string, opts = { mainKclPathName: 'main.kcl' }): Promise<ExpectedWebSocketResponse> =>
+      submit: (
+        kclStr: string,
+        opts = { mainKclPathName: 'main.kcl' }
+      ): Promise<ExpectedWebSocketResponse> =>
         new Promise((resolve) => {
           const onMessage = (ev: MessageEvent<WorkerMessage>) => {
             const msg = ev.data

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -214,7 +214,7 @@ export class WebRTC extends EventTarget {
         this.workerWebRTC,
         'message'
       ),
-      submit: (kclStr: string): Promise<ExpectedWebSocketResponse> =>
+      submit: (kclStr: string, opts = { mainKclPathName: 'main.kcl' }): Promise<ExpectedWebSocketResponse> =>
         new Promise((resolve) => {
           const onMessage = (ev: MessageEvent<WorkerMessage>) => {
             const msg = ev.data
@@ -234,7 +234,7 @@ export class WebRTC extends EventTarget {
             to: 'wasm',
             payload: {
               type: 'execute',
-              data: [kclStr],
+              data: [kclStr, opts],
             },
           })
         }),

--- a/src/worker-webrtc.ts
+++ b/src/worker-webrtc.ts
@@ -131,8 +131,8 @@ const engineCommandManagerLite = {
 const kclExecute = (
   kclStrOrProject: string | Map<string, string>,
   opts = {
-    mainKclPathName: 'main.kcl'
-  },
+    mainKclPathName: 'main.kcl',
+  }
 ) => {
   const projectFsManagerLiteKclStr = (kclStr: string) => ({
     async readFile(_targetPath: string): Promise<Uint8Array> {
@@ -174,7 +174,11 @@ const kclExecute = (
     projectFsManagerLite
   )
   const program = zooWasm.parse_wasm(entryFile)[0]
-  return executorContext.execute(JSON.stringify(program), opts.mainKclPathName, '{}')
+  return executorContext.execute(
+    JSON.stringify(program),
+    opts.mainKclPathName,
+    '{}'
+  )
 }
 
 self.addEventListener('message', (ev: MessageEvent & MessageEventMain) => {

--- a/src/worker-webrtc.ts
+++ b/src/worker-webrtc.ts
@@ -130,7 +130,9 @@ const engineCommandManagerLite = {
 // * (TODO: Or a blob of bytes that's a tarball from our Aquarium.)
 const kclExecute = (
   kclStrOrProject: string | Map<string, string>,
-  mainKclPathName = 'main.kcl'
+  opts = {
+    mainKclPathName: 'main.kcl'
+  },
 ) => {
   const projectFsManagerLiteKclStr = (kclStr: string) => ({
     async readFile(_targetPath: string): Promise<Uint8Array> {
@@ -165,14 +167,14 @@ const kclExecute = (
   const entryFile =
     typeof kclStrOrProject === 'string'
       ? kclStrOrProject
-      : kclStrOrProject.get(mainKclPathName)
+      : kclStrOrProject.get(opts.mainKclPathName)
 
   const executorContext = new zooWasm.Context(
     engineCommandManagerLite,
     projectFsManagerLite
   )
   const program = zooWasm.parse_wasm(entryFile)[0]
-  return executorContext.execute(JSON.stringify(program), mainKclPathName, '{}')
+  return executorContext.execute(JSON.stringify(program), opts.mainKclPathName, '{}')
 }
 
 self.addEventListener('message', (ev: MessageEvent & MessageEventMain) => {
@@ -192,7 +194,7 @@ self.addEventListener('message', (ev: MessageEvent & MessageEventMain) => {
       // Special cases.
       if (msg.payload.type === 'execute') {
         // Returns when the wasm code is finished processing.
-        kclExecute(msg.payload.data[0])
+        kclExecute(msg.payload.data[0], msg.payload.data[1])
           .then((resolved) => {
             postMessage({
               from: 'wasm',


### PR DESCRIPTION
Allow files not named `main.kcl` to run as the entry point for both individual and projects. This is a clear DevX/UX issue that coreypdx hit immediately when trying to use the viewer. I had expected it but I wanted to see the result first before weakening the requirement.

It would be nice to follow up sometime with a configurable entry point in `project.toml`.