### PR TITLE
Add OAuth2 auth code flow support, and minor WebRTC mouse start/stop

### DIFF
--- a/__tests__/client-oauth.test.ts
+++ b/__tests__/client-oauth.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Client } from '../src/client'
+
+const localStorageStateKey = 'oauth2authcodepkce-state'
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  clear() {
+    this.values.clear()
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Client OAuth2', () => {
+  it('does not touch browser OAuth state until OAuth is used', () => {
+    expect(() => new Client({ clientId: 'client-id' })).not.toThrow()
+  })
+
+  it('updates the client token after exchanging an authorization code', async () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      localStorageStateKey,
+      JSON.stringify({
+        stage: 0,
+        stateQueryParam: 'state-value',
+        codeVerifier: 'code-verifier',
+      })
+    )
+
+    vi.stubGlobal('localStorage', storage)
+    vi.stubGlobal('location', {
+      href: 'http://localhost:3000/callback?code=auth-code&state=state-value',
+      origin: 'http://localhost:3000',
+      pathname: '/callback',
+    })
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'access-token',
+            expires_in: 3600,
+            refresh_token: 'refresh-token',
+            scope: 'modeling',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const client = new Client({
+      baseUrl: 'https://api.zoo.dev/',
+      clientId: 'client-id',
+      redirectUrl: 'http://localhost:3000/callback',
+    })
+
+    await expect(client.isReturningFromAuthServer()).resolves.toBe(true)
+    await client.getAccessToken()
+
+    expect(client.token).toBe('access-token')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.zoo.dev/oauth2/token',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+})

--- a/__tests__/client-oauth.test.ts
+++ b/__tests__/client-oauth.test.ts
@@ -1,7 +1,40 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Client } from '../src/client'
+import type { ClientOptions } from '../src/client'
+import type { AccessContext } from '@kittycad/oauth2-auth-code-pkce'
 
-const localStorageStateKey = 'oauth2authcodepkce-state'
+const { oauth2Instances, MockOAuth2AuthCodePKCE } = vi.hoisted(() => {
+  const oauth2Instances: MockOAuth2AuthCodePKCE[] = []
+
+  class MockOAuth2AuthCodePKCE {
+    isHTTPDecoratorActive = vi.fn()
+    decorateFetchHTTPClient = vi.fn((fetchClient: typeof fetch) => fetchClient)
+    fetchAuthorizationCode = vi.fn()
+    isReturningFromAuthServer = vi.fn(async () => true)
+    getAccessToken = vi.fn(async () => ({
+      token: { value: 'access-token', expiry: '2026-01-01T00:00:00.000Z' },
+    }))
+    reset = vi.fn()
+
+    constructor(
+      public config: {
+        authorizationUrl: string
+        tokenUrl: string
+        clientId?: string
+        redirectUrl: string
+        scopes: string[]
+        onAccessTokenExpiry: (
+          refreshAccessToken: () => Promise<AccessContext>
+        ) => Promise<AccessContext>
+        onInvalidGrant: () => void
+      }
+    ) {
+      oauth2Instances.push(this)
+    }
+  }
+
+  return { oauth2Instances, MockOAuth2AuthCodePKCE }
+})
 
 class MemoryStorage {
   private values = new Map<string, string>()
@@ -23,8 +56,13 @@ class MemoryStorage {
   }
 }
 
+vi.mock('@kittycad/oauth2-auth-code-pkce', () => ({
+  OAuth2AuthCodePKCE: MockOAuth2AuthCodePKCE,
+}))
+
 afterEach(() => {
   vi.unstubAllGlobals()
+  oauth2Instances.length = 0
 })
 
 describe('Client OAuth2', () => {
@@ -33,22 +71,7 @@ describe('Client OAuth2', () => {
   })
 
   it('updates the client token after exchanging an authorization code', async () => {
-    const storage = new MemoryStorage()
-    storage.setItem(
-      localStorageStateKey,
-      JSON.stringify({
-        stage: 0,
-        stateQueryParam: 'state-value',
-        codeVerifier: 'code-verifier',
-      })
-    )
-
-    vi.stubGlobal('localStorage', storage)
-    vi.stubGlobal('location', {
-      href: 'http://localhost:3000/callback?code=auth-code&state=state-value',
-      origin: 'http://localhost:3000',
-      pathname: '/callback',
-    })
+    vi.stubGlobal('localStorage', new MemoryStorage())
     const fetchSpy = vi.fn(
       async () =>
         new Response(
@@ -76,9 +99,42 @@ describe('Client OAuth2', () => {
     await client.getAccessToken()
 
     expect(client.token).toBe('access-token')
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://api.zoo.dev/oauth2/token',
-      expect.objectContaining({ method: 'POST' })
+    expect(oauth2Instances).toHaveLength(1)
+    expect(oauth2Instances[0].config).toEqual(
+      expect.objectContaining({
+        authorizationUrl: 'https://api.zoo.dev/oauth2/authorize',
+        tokenUrl: 'https://api.zoo.dev/oauth2/token',
+        clientId: 'client-id',
+        redirectUrl: 'http://localhost:3000/callback',
+      })
     )
+    expect(oauth2Instances[0].decorateFetchHTTPClient).toHaveBeenCalledWith(
+      fetchSpy
+    )
+  })
+
+  it('updates the client token when OAuth refreshes an expired access token', async () => {
+    vi.stubGlobal('localStorage', new MemoryStorage())
+    const refreshAccessToken = vi.fn(async () => ({
+      token: {
+        value: 'refreshed-access-token',
+        expiry: '2026-01-01T00:00:00.000Z',
+      },
+    }))
+    const onAccessTokenExpiry: ClientOptions['onAccessTokenExpiry'] = vi.fn(
+      async (refresh) => refresh()
+    )
+
+    const client = new Client({
+      clientId: 'client-id',
+      redirectUrl: 'http://localhost:3000/callback',
+      onAccessTokenExpiry,
+    })
+
+    await oauth2Instances[0].config.onAccessTokenExpiry(refreshAccessToken)
+
+    expect(refreshAccessToken).toHaveBeenCalled()
+    expect(onAccessTokenExpiry).toHaveBeenCalledWith(refreshAccessToken)
+    expect(client.token).toBe('refreshed-access-token')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.148",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.28",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.0.28",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.148",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.148",
+        "@kittycad/oauth2-auth-code-pkce": "^3.1.0",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",
         "cross-fetch": "^4.0.0",
@@ -2100,6 +2101,12 @@
       "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.148.tgz",
       "integrity": "sha512-X2/q6xMidxskOjQc8cTjaZ3vEJ4hDGcXVZu2Em1CNDA+5cdIOiN87ypC8aQFE6ATX31RPCnEQ0VitseIJdUMiA==",
       "license": "MIT"
+    },
+    "node_modules/@kittycad/oauth2-auth-code-pkce": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@kittycad/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-3.1.0.tgz",
+      "integrity": "sha512-BdD8z6yQz+QsogrkdRMBsna7lHfrGcLfK2h4Qzt87tI+3kXzTDtvUOMmMO8up9dsChJG7aTWoPXLieNTs3xonA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.148",
-        "@kittycad/oauth2-auth-code-pkce": "^3.1.0",
+        "@kittycad/oauth2-auth-code-pkce": "^3.1.3",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",
         "cross-fetch": "^4.0.0",
@@ -2103,9 +2103,9 @@
       "license": "MIT"
     },
     "node_modules/@kittycad/oauth2-auth-code-pkce": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@kittycad/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-3.1.0.tgz",
-      "integrity": "sha512-BdD8z6yQz+QsogrkdRMBsna7lHfrGcLfK2h4Qzt87tI+3kXzTDtvUOMmMO8up9dsChJG7aTWoPXLieNTs3xonA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@kittycad/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-3.1.3.tgz",
+      "integrity": "sha512-icTsMYnSrGfPcfJARgb9gCibKUf/xKZMFAnf5mD6UnAs6SjEfA6nr6cBYZVF2bDfSoAhRm8RpsQppjseVKoFWQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@msgpack/msgpack": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "license": "MIT",
   "dependencies": {
     "@kittycad/kcl-wasm-lib": "0.1.148",
-    "@kittycad/oauth2-auth-code-pkce": "^3.1.0",
+    "@kittycad/oauth2-auth-code-pkce": "^3.1.3",
     "@msgpack/msgpack": "^3.1.3",
     "bson": "^7.1.1",
     "cross-fetch": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "license": "MIT",
   "dependencies": {
     "@kittycad/kcl-wasm-lib": "0.1.148",
+    "@kittycad/oauth2-auth-code-pkce": "^3.1.0",
     "@msgpack/msgpack": "^3.1.3",
     "bson": "^7.1.1",
     "cross-fetch": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
   "author": "Kurt Hutten <kurt@zoo.dev>",
   "license": "MIT",
   "dependencies": {
+    "@kittycad/kcl-wasm-lib": "0.1.148",
     "@msgpack/msgpack": "^3.1.3",
     "bson": "^7.1.1",
     "cross-fetch": "^4.0.0",
-    "@kittycad/kcl-wasm-lib": "0.1.148",
     "openapi-types": "^12.0.0",
     "rollup-plugin-web-worker-loader": "^1.7.0",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.0.28",
+  "version": "4.1.0",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -48,7 +48,7 @@ export class Client {
   ) => Promise<AccessContext>
   onInvalidGrant?: (refreshAuthCodeOrRefreshToken: () => Promise<void>) => void
 
-  private oauth2?: OAuth2AuthCodePKCE
+  public oauth2?: OAuth2AuthCodePKCE
 
   constructor(tokenOrOpts?: string | ClientOptions) {
     const env = typeof process !== 'undefined' ? process.env : undefined

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,9 @@
+import {
+  type AccessContext,
+  type ObjStringDict,
+  OAuth2AuthCodePKCE,
+} from '@kittycad/oauth2-auth-code-pkce'
+
 // Load fetch polyfill dynamically only when needed (older Node),
 // and avoid bundlers pulling it into browser builds.
 try {
@@ -21,12 +27,28 @@ export interface ClientOptions {
   token?: string
   baseUrl?: string
   fetch?: typeof fetch
+  clientId?: string
+  redirectUrl?: string
+  scopes?: string[]
+  onAccessTokenExpiry?: (
+    refreshAccessToken: () => Promise<AccessContext>
+  ) => Promise<AccessContext>
+  onInvalidGrant?: (refreshAuthCodeOrRefreshToken: () => Promise<void>) => void
 }
 
 export class Client {
   token?: string
   baseUrl?: string
   fetch?: typeof fetch
+  clientId?: string
+  redirectUrl?: string
+  scopes?: string[]
+  onAccessTokenExpiry?: (
+    refreshAccessToken: () => Promise<AccessContext>
+  ) => Promise<AccessContext>
+  onInvalidGrant?: (refreshAuthCodeOrRefreshToken: () => Promise<void>) => void
+
+  private oauth2?: OAuth2AuthCodePKCE
 
   constructor(tokenOrOpts?: string | ClientOptions) {
     const env = typeof process !== 'undefined' ? process.env : undefined
@@ -41,11 +63,87 @@ export class Client {
       this.token = tokenOrOpts.token
       this.baseUrl = tokenOrOpts.baseUrl
       this.fetch = tokenOrOpts.fetch
+      this.clientId = tokenOrOpts.clientId
+      this.redirectUrl = tokenOrOpts.redirectUrl
+      this.scopes = tokenOrOpts.scopes
+      this.onAccessTokenExpiry = tokenOrOpts.onAccessTokenExpiry
+      this.onInvalidGrant = tokenOrOpts.onInvalidGrant
     }
 
     this.token ??= envToken
     this.baseUrl ??= envHost
+
+    if (this.clientId) {
+      if (typeof localStorage !== 'undefined') {
+        this.oauth2 = this.createOAuth2Client()
+        this.oauth2.isHTTPDecoratorActive(true)
+        this.fetch = this.oauth2.decorateFetchHTTPClient(
+          this.fetch || fetch
+        ) as typeof fetch
+      }
+    }
   }
+
+  authorize(oneTimeParams?: ObjStringDict): Promise<void> {
+    return this.oauth2!.fetchAuthorizationCode(oneTimeParams)
+  }
+
+  isReturningFromAuthServer(): Promise<boolean> {
+    return this.oauth2!.isReturningFromAuthServer()
+  }
+
+  async getAccessToken(): Promise<AccessContext | undefined> {
+    const context = await this.oauth2!.getAccessToken()
+    this.updateTokenFromAccessContext(context)
+    return context
+  }
+
+  resetOAuth2(): void {
+    this.oauth2!.reset()
+    this.token = undefined
+  }
+
+  private createOAuth2Client(): OAuth2AuthCodePKCE {
+    const baseUrl = this.baseUrl || 'https://api.zoo.dev'
+    const redirectUrl = this.redirectUrl || getCurrentUrlWithoutSearch()
+
+    if (!redirectUrl) {
+      throw new Error(
+        'OAuth2 requires redirectUrl when the current browser URL is unavailable.'
+      )
+    }
+
+    return new OAuth2AuthCodePKCE({
+      authorizationUrl: joinUrl(baseUrl, '/oauth2/authorize'),
+      tokenUrl: joinUrl(baseUrl, '/oauth2/token'),
+      clientId: this.clientId,
+      redirectUrl,
+      scopes: this.scopes || [],
+      onAccessTokenExpiry: async (refreshAccessToken) => {
+        const context = await (this.onAccessTokenExpiry
+          ? this.onAccessTokenExpiry(refreshAccessToken)
+          : refreshAccessToken())
+        this.updateTokenFromAccessContext(context)
+        return context
+      },
+      onInvalidGrant: this.onInvalidGrant || (() => {}),
+    })
+  }
+
+  private updateTokenFromAccessContext(
+    context: AccessContext | undefined
+  ): void {
+    if (context?.token?.value) this.token = context.token.value
+  }
+}
+
+function getCurrentUrlWithoutSearch(): string | undefined {
+  if (typeof location === 'undefined') return undefined
+  return `${location.origin}${location.pathname}`
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
 }
 
 /**

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -169,14 +169,64 @@ export class WebRTC extends EventTarget {
     this.rtcPeerConnection.close()
   }
 
-  start() {
-    this.workerWebRTC.postMessage({
-      to: 'worker',
-      payload: {
-        type: 'start',
-        data: [this.zooClientArgs],
-      },
-    })
+  async start() {
+    // Cannot be passed over the Worker boundary.
+    // zooClientArgs.client.token will either have a valid token, invalid, or
+    // unset / undefined. The Worker will notify us if something goes wrong, in
+    // which case we will fire an authorization.
+    const oauth2 = this.zooClientArgs.client.oauth2
+    delete this.zooClientArgs.client.oauth2
+
+    // Our initial auth is hella confusing, because the 1st will always show
+    // 'auth_token_missing'. Very heuristic.
+    const onMessage = (ev: MessageEvent<WorkerMessage>) => {
+      const msg = ev.data
+      if (!('from' in msg && msg.from === 'websocket')) {
+        return
+      }
+      // @ts-expect-error
+      if (msg.payload.data.indexOf('auth_token_invalid') >= 0) {
+        this.workerWebRTC.removeEventListener('message', onMessage)
+        oauth2.fetchAuthorizationCode()
+      }
+    }
+
+    void oauth2
+      .getAccessToken()
+      .then((context) => {
+        if (context?.token?.value) {
+          this.zooClientArgs.client.token = context?.token?.value
+        }
+
+        // Trigger the "auth_token_invalid" message, more reliable than
+        //  "auth_token_missing", using the NIL UUID.
+        if (this.zooClientArgs.client.token === undefined) {
+          this.zooClientArgs.client.token =
+            '00000000-0000-0000-0000-000000000000'
+        }
+
+        // Not needed for us.
+        delete this.zooClientArgs.client.fetch
+
+        this.workerWebRTC.addEventListener('message', onMessage)
+
+        this.workerWebRTC.postMessage({
+          to: 'worker',
+          payload: {
+            type: 'start',
+            data: [this.zooClientArgs],
+          },
+        })
+      })
+      .catch((error: unknown) => {
+        if (
+          typeof error === 'object' &&
+          'kind' in error &&
+          error.kind === 'ErrorNoAuthCode'
+        ) {
+          oauth2.fetchAuthorizationCode()
+        }
+      })
   }
 
   // For regular wasm calls, for whatever reason devs need it for.
@@ -372,6 +422,7 @@ export class WebRTC extends EventTarget {
     if (msg.payload.type !== 'message') {
       return
     }
+
     this.iceOnMessage(msg.payload)
   }
 

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -407,8 +407,8 @@ export class WebRTC extends EventTarget {
         if (interaction === undefined) {
           return
         }
-        
-        const payload =  {
+
+        const payload = {
           type: 'send',
           data: [
             JSON.stringify({
@@ -425,7 +425,7 @@ export class WebRTC extends EventTarget {
             }),
           ],
         }
-        
+
         this.workerWebRTC.postMessage({
           to: 'websocket',
           payload,
@@ -445,7 +445,7 @@ export class WebRTC extends EventTarget {
       }
 
       pointerState = PointerState.UP
-      
+
       const payload = {
         type: 'send',
         data: [

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -407,27 +407,30 @@ export class WebRTC extends EventTarget {
         if (interaction === undefined) {
           return
         }
-
+        
+        const payload =  {
+          type: 'send',
+          data: [
+            JSON.stringify({
+              type: 'modeling_cmd_req',
+              cmd_id: '00000000-0000-0000-0000-000000000000',
+              cmd: {
+                type: pointerStateToType[targetPointerState],
+                interaction,
+                window: {
+                  x: ev.offsetX,
+                  y: ev.offsetY,
+                },
+              },
+            }),
+          ],
+        }
+        
         this.workerWebRTC.postMessage({
           to: 'websocket',
-          payload: {
-            type: 'send',
-            data: [
-              JSON.stringify({
-                type: 'modeling_cmd_req',
-                cmd_id: '00000000-0000-0000-0000-000000000000',
-                cmd: {
-                  type: pointerStateToType[targetPointerState],
-                  interaction,
-                  window: {
-                    x: ev.offsetX,
-                    y: ev.offsetY,
-                  },
-                },
-              }),
-            ],
-          },
+          payload,
         })
+        this.channel?.send(payload.data[0])
 
         pointerButton = ev.button
         pointerState = targetPointerState
@@ -442,27 +445,30 @@ export class WebRTC extends EventTarget {
       }
 
       pointerState = PointerState.UP
+      
+      const payload = {
+        type: 'send',
+        data: [
+          JSON.stringify({
+            type: 'modeling_cmd_req',
+            cmd_id: '00000000-0000-0000-0000-000000000000',
+            cmd: {
+              type: pointerStateToType[pointerState],
+              interaction,
+              window: {
+                x: ev.offsetX,
+                y: ev.offsetY,
+              },
+            },
+          }),
+        ],
+      }
 
       this.workerWebRTC.postMessage({
         to: 'websocket',
-        payload: {
-          type: 'send',
-          data: [
-            JSON.stringify({
-              type: 'modeling_cmd_req',
-              cmd_id: '00000000-0000-0000-0000-000000000000',
-              cmd: {
-                type: pointerStateToType[pointerState],
-                interaction,
-                window: {
-                  x: ev.offsetX,
-                  y: ev.offsetY,
-                },
-              },
-            }),
-          ],
-        },
+        payload,
       })
+      this.channel?.send(payload.data[0])
     }
 
     let sequence = 0


### PR DESCRIPTION
This uses the new `@kittycad/oauth2-auth-code-pkce` https://github.com/KittyCAD/oauth2-auth-code-pkce

It allows us to use the new OAuth2 auth code flow with PKCE for external applications that use our API.

To dogfood, we will be using it with https://viewer.zoo.dev. Eventually this should be our primary authorization method.

