### PR TITLE
Handle stale authorization code more gracefully; strip ZooClient of non-serializable when passing to Worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kittycad/lib",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.148",
-        "@kittycad/oauth2-auth-code-pkce": "^3.1.3",
+        "@kittycad/oauth2-auth-code-pkce": "^3.1.4",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",
         "cross-fetch": "^4.0.0",
@@ -2103,9 +2103,9 @@
       "license": "MIT"
     },
     "node_modules/@kittycad/oauth2-auth-code-pkce": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@kittycad/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-3.1.3.tgz",
-      "integrity": "sha512-icTsMYnSrGfPcfJARgb9gCibKUf/xKZMFAnf5mD6UnAs6SjEfA6nr6cBYZVF2bDfSoAhRm8RpsQppjseVKoFWQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@kittycad/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-3.1.4.tgz",
+      "integrity": "sha512-hDVw+Mq3jwFcgh0NNwEn+QID+9fIvXyasI4XhHIAQ0yQMqYNI/rV9BSeGVm2y5JKpXb3FfOZk3PNL0k7z8qnBg==",
       "license": "Apache-2.0"
     },
     "node_modules/@msgpack/msgpack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycad/lib",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Javascript library for KittyCAD API",
   "type": "module",
   "keywords": [
@@ -82,7 +82,7 @@
   "license": "MIT",
   "dependencies": {
     "@kittycad/kcl-wasm-lib": "0.1.148",
-    "@kittycad/oauth2-auth-code-pkce": "^3.1.3",
+    "@kittycad/oauth2-auth-code-pkce": "^3.1.4",
     "@msgpack/msgpack": "^3.1.3",
     "bson": "^7.1.1",
     "cross-fetch": "^4.0.0",

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -12,7 +12,7 @@ type ExpectedWebSocketResponse =
   | FailureWebSocketResponse
   | SuccessWebSocketResponse
   | Error
-  
+
 const cloneWithoutNonSerializable = (a: unknown): unknown => {
   return JSON.parse(JSON.stringify(a))
 }
@@ -183,18 +183,21 @@ export class WebRTC extends EventTarget {
     // 'auth_token_missing'.
     const onMessage = (ev: MessageEvent<WorkerMessage>) => {
       const msg = ev.data
-      if (!('from' in msg
-        && msg.from === 'websocket'
-        && 'payload' in msg
-        && typeof msg.payload === 'object'
-        && 'data' in msg.payload
-        && typeof msg.payload.data === 'string')
+      if (
+        !(
+          'from' in msg &&
+          msg.from === 'websocket' &&
+          'payload' in msg &&
+          typeof msg.payload === 'object' &&
+          'data' in msg.payload &&
+          typeof msg.payload.data === 'string'
+        )
       ) {
         return
       }
       if (msg.payload.data.indexOf('auth_token_invalid') >= 0) {
         this.workerWebRTC.removeEventListener('message', onMessage)
-        
+
         // Will redirect us to the authorization server.
         this.zooClientArgs.client.oauth2.fetchAuthorizationCode()
       }
@@ -225,13 +228,17 @@ export class WebRTC extends EventTarget {
           },
         })
       })
+      // Should maybe move this up into @kittycad/oauth2-auth-code-pkce
       .catch((error: unknown) => {
-        if (
-          typeof error === 'object' &&
-          'kind' in error &&
-          error.kind === EErrorOAuth2.ErrorNoAuthCode
-        ) {
-          this.zooClientArgs.client.oauth2.fetchAuthorizationCode()
+        if (typeof error === 'object' && 'kind' in error) {
+          if (
+            [
+              EErrorOAuth2.ErrorNoAuthCode,
+              EErrorOAuth2.ErrorAccessTokenResponse,
+            ].some((e) => e === error.kind)
+          ) {
+            this.zooClientArgs.client.oauth2.fetchAuthorizationCode()
+          }
         }
       })
   }

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -1,3 +1,4 @@
+import { EErrorOAuth2 } from '@kittycad/oauth2-auth-code-pkce'
 import { Client } from './client'
 import ModelingCommandsWs from './api/modeling/modeling_commands_ws'
 import {
@@ -11,6 +12,10 @@ type ExpectedWebSocketResponse =
   | FailureWebSocketResponse
   | SuccessWebSocketResponse
   | Error
+  
+const cloneWithoutNonSerializable = (a: unknown): unknown => {
+  return JSON.parse(JSON.stringify(a))
+}
 
 // Based on human interaction speeds.
 const throttle = (
@@ -170,28 +175,32 @@ export class WebRTC extends EventTarget {
   }
 
   async start() {
-    // Cannot be passed over the Worker boundary.
     // zooClientArgs.client.token will either have a valid token, invalid, or
     // unset / undefined. The Worker will notify us if something goes wrong, in
     // which case we will fire an authorization.
-    const oauth2 = this.zooClientArgs.client.oauth2
-    delete this.zooClientArgs.client.oauth2
 
     // Our initial auth is hella confusing, because the 1st will always show
-    // 'auth_token_missing'. Very heuristic.
+    // 'auth_token_missing'.
     const onMessage = (ev: MessageEvent<WorkerMessage>) => {
       const msg = ev.data
-      if (!('from' in msg && msg.from === 'websocket')) {
+      if (!('from' in msg
+        && msg.from === 'websocket'
+        && 'payload' in msg
+        && typeof msg.payload === 'object'
+        && 'data' in msg.payload
+        && typeof msg.payload.data === 'string')
+      ) {
         return
       }
-      // @ts-expect-error
       if (msg.payload.data.indexOf('auth_token_invalid') >= 0) {
         this.workerWebRTC.removeEventListener('message', onMessage)
-        oauth2.fetchAuthorizationCode()
+        
+        // Will redirect us to the authorization server.
+        this.zooClientArgs.client.oauth2.fetchAuthorizationCode()
       }
     }
 
-    void oauth2
+    void this.zooClientArgs.client.oauth2
       .getAccessToken()
       .then((context) => {
         if (context?.token?.value) {
@@ -205,16 +214,14 @@ export class WebRTC extends EventTarget {
             '00000000-0000-0000-0000-000000000000'
         }
 
-        // Not needed for us.
-        delete this.zooClientArgs.client.fetch
-
         this.workerWebRTC.addEventListener('message', onMessage)
 
         this.workerWebRTC.postMessage({
           to: 'worker',
           payload: {
             type: 'start',
-            data: [this.zooClientArgs],
+            // Cannot serialize functions across the Worker boundary.
+            data: [cloneWithoutNonSerializable(this.zooClientArgs)],
           },
         })
       })
@@ -222,9 +229,9 @@ export class WebRTC extends EventTarget {
         if (
           typeof error === 'object' &&
           'kind' in error &&
-          error.kind === 'ErrorNoAuthCode'
+          error.kind === EErrorOAuth2.ErrorNoAuthCode
         ) {
-          oauth2.fetchAuthorizationCode()
+          this.zooClientArgs.client.oauth2.fetchAuthorizationCode()
         }
       })
   }


### PR DESCRIPTION
Users can hit a stale authorization code if trying to refresh on the web page after an expired or invalid access code. We now handle this by simply refreshing it and putting them back into the auth flow.

The other fix is minor, instead of using `delete <property>`, we now strip non-serializable properties more robustly with vendor JSON parsing/stringifying.