### PR TITLE
Fix multipart JSON request body generation

### DIFF
--- a/gen/apiGen.ts
+++ b/gen/apiGen.ts
@@ -671,7 +671,7 @@ export default async function apiGen(lookup: Record<string, string>) {
             omitContentType: isMultipart || bodyLine === '',
             bodyLine,
             multipartAppendBody: inputParams.includes('body')
-              ? "formData.append('event', JSON.stringify(body))"
+              ? "formData.append('body', new Blob([JSON.stringify(body)], { type: 'application/json' }))"
               : '',
             fnJsDoc: buildOperationJsDoc(operation.specSection, {
               operationId,

--- a/src/api/file/create_file_conversion_options.ts
+++ b/src/api/file/create_file_conversion_options.ts
@@ -56,7 +56,10 @@ export default async function create_file_conversion_options({
   files.forEach((file) => {
     formData.append(file.name, file.data, file.name)
   })
-  formData.append('event', JSON.stringify(body))
+  formData.append(
+    'body',
+    new Blob([JSON.stringify(body)], { type: 'application/json' })
+  )
 
   const fetchOptions: RequestInit = {
     method: 'POST',


### PR DESCRIPTION
## Summary

- generate multipart JSON under the API field `body`
- send the JSON part with `application/json`
- regenerate the affected file-conversion endpoint

Fixes #658.

## Testing

- `npm run gen`
- `npm run build`
- `npm run test -- --run` (196 tests passed)
- runtime assertion of the generated FormData field name and Blob content type